### PR TITLE
feat: add reset function to component

### DIFF
--- a/src/lib/Turnstile.svelte
+++ b/src/lib/Turnstile.svelte
@@ -95,6 +95,10 @@
     function callback(token: string) {
         dispatch('turnstile-callback', { token });
     }
+    
+    export function reset() {
+		return window.turnstile.reset(widgetId);
+	}
 
     const turnstile: Action = (node) => {
         const id = window.turnstile.render(node, {


### PR DESCRIPTION
Allow other components to use bind:this and call the .reset() function when the token is already sent/used via form/endpoint.