### PR TITLE
Add Svelte v4 to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"vite": "^4.3.9"
 	},
 	"peerDependencies": {
-		"svelte": "^3.58.0"
+		"svelte": "^3.58.0 || ^4.0.0"
 	},
 	"dependencies": {
 		"turnstile-types": "^1.1.2"


### PR DESCRIPTION
The peerDependencies field in package.json was using Svelte v3, but now that v4 is out we need to list it to avoid getting warnings on npm install.

Closes #16 