### PR TITLE
Add missing props/events, improve documentation, and clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,30 +30,34 @@ The only required prop is the `siteKey` which you can get from [adding a site he
 
 | Prop            | Type                                          | Description                                                                                    | Required |
 |-----------------|-----------------------------------------------|------------------------------------------------------------------------------------------------|----------|
-| `siteKey`       | `string`                                      | sitekey for your website                                                                       | ✅       |
-| `theme`         | `'light' \| 'dark' \| 'auto'`                 | colour theme of the widget (defaults to `auto`)                                                | ❌       |
-| `size`          | `'normal' \| 'compact'`                       | size of the widget (defaults to `normal`)                                                      | ❌       |
-| `action`        | `string`                                      | A string that can be used to differentiate widgets, returned on validation                     | ❌       |
-| `cData`         | `string`                                      | A string that can attach customer data to a challange, returned on validation                  | ❌       |
-| `tabIndex`      | `number`                                      | Used for accessibility (defaults to `0`)                                                       | ❌       |
-| `forms`         | `boolean`                                     | if true the response token will be a property on the form data (default `true`)                | ❌       |
-| `formsField`    | `string`                                      | the `name` of the input which will appear on the form data (default `cf-turnstile-response`)   | ❌       |
-| `retry`         | `'auto' \| 'never'`                           | should the widget automatically retry to obtain a token if it did not succeed (default `auto`) | ❌       |
-| `retryInterval` | `number`                                      | if `retry` is true, this controls the time between attempts in milliseconds (default `8000`)   | ❌       |
-| `language`      | `SupportedLanguage \| 'auto'`                 | the language turnstile should use (default `auto`)                                             | ❌       |
-| `execution`     | `'render' \| 'execute'`                       | controls when to obtain the token of the widget (default `render`)                             | ❌       |
-| `appearance`    | `'always' \| 'execute' \| 'interaction-only'` | controls when the widget is visible. (default `always`)                                        | ❌       |
+| `siteKey`       | `string`                                      | sitekey for your website                                                                       | ✅        |
+| `theme`         | `'light' \| 'dark' \| 'auto'`                 | colour theme of the widget (defaults to `auto`)                                                |          |
+| `size`          | `'normal' \| 'compact'`                       | size of the widget (defaults to `normal`)                                                      |          |
+| `action`        | `string`                                      | A string that can be used to differentiate widgets, returned on validation                     |          |
+| `cData`         | `string`                                      | A string that can attach customer data to a challange, returned on validation                  |          |
+| `tabIndex`      | `number`                                      | Used for accessibility (defaults to `0`)                                                       |          |
+| `forms`         | `boolean`                                     | if true the response token will be a property on the form data (default `true`)                |          |
+| `formsField`    | `string`                                      | the `name` of the input which will appear on the form data (default `cf-turnstile-response`)   |          |
+| `retry`         | `'auto' \| 'never'`                           | should the widget automatically retry to obtain a token if it did not succeed (default `auto`) |          |
+| `retryInterval` | `number`                                      | if `retry` is true, this controls the time between attempts in milliseconds (default `8000`)   |          |
+| `language`      | `SupportedLanguage \| 'auto'`                 | the language turnstile should use (default `auto`)                                             |          |
+| `execution`     | `'render' \| 'execute'`                       | controls when to obtain the token of the widget (default `render`)                             |          |
+| `appearance`    | `'always' \| 'execute' \| 'interaction-only'` | controls when the widget is visible. (default `always`)                                        |          |
+
 
 For more information about some of the props and a list of `SupportedLanguage`'s [checkout the Cloudflare Documentation](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configurations).
 
 ## Events
 
-| Event                | Data                | Description                                                    |
-|----------------------|---------------------|----------------------------------------------------------------|
-| `turnstile-error`    | `{}`                | Emitted when a user fails verification                         |
-| `turnstile-expired`  | `{}`                | Emitted when a challenge expires and does not reset the widget |
-| `turnstile-timeout`  | `{}`                | Emitted when a challenge expires and does reset the widget     |
-| `turnstile-callback` | `{ token: string }` | Emitted when a user passes a challenge                         |
+| Event                         | Data                | Description                                                    |
+|-------------------------------|---------------------|----------------------------------------------------------------|
+| `callback`                    | `{ token: string }` | Emitted when a user passes a challenge                         |
+| `error-callback`              | `{}`                | Emitted when a user fails verification                         |
+| `expired-callback`            | `{}`                | Emitted when a challenge expires and does not reset the widget |
+| `timeout-callback`            | `{}`                | Emitted when a challenge expires and does reset the widget     |
+| `before-interactive-callback` | `{}`                | Emitted before the challenge enters interactive mode           |
+| `after-interactive-callback`  | `{}`                | Emitted when the challenge has left interactive mode           |
+| `unsupported-callback`        | `{}`                | Emitted when a given client/browser is not supported           |
 
 # Validate CAPTCHA
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ The only required prop is the `siteKey` which you can get from [adding a site he
 ## Props
 
 | Prop            | Type                                          | Description                                                                                    | Required |
-|-----------------|-----------------------------------------------|------------------------------------------------------------------------------------------------|----------|
-| `siteKey`       | `string`                                      | sitekey for your website                                                                       | ✅        |
+| --------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------- | -------- |
+| `siteKey`       | `string`                                      | sitekey for your website                                                                       | ✅       |
 | `theme`         | `'light' \| 'dark' \| 'auto'`                 | colour theme of the widget (defaults to `auto`)                                                |          |
 | `size`          | `'normal' \| 'compact'`                       | size of the widget (defaults to `normal`)                                                      |          |
 | `action`        | `string`                                      | A string that can be used to differentiate widgets, returned on validation                     |          |
@@ -44,13 +44,12 @@ The only required prop is the `siteKey` which you can get from [adding a site he
 | `execution`     | `'render' \| 'execute'`                       | controls when to obtain the token of the widget (default `render`)                             |          |
 | `appearance`    | `'always' \| 'execute' \| 'interaction-only'` | controls when the widget is visible. (default `always`)                                        |          |
 
-
 For more information about some of the props and a list of `SupportedLanguage`'s [checkout the Cloudflare Documentation](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configurations).
 
 ## Events
 
 | Event                         | Data                | Description                                                    |
-|-------------------------------|---------------------|----------------------------------------------------------------|
+| ----------------------------- | ------------------- | -------------------------------------------------------------- |
 | `callback`                    | `{ token: string }` | Emitted when a user passes a challenge                         |
 | `error-callback`              | `{}`                | Emitted when a user fails verification                         |
 | `expired-callback`            | `{}`                | Emitted when a challenge expires and does not reset the widget |
@@ -105,6 +104,7 @@ async function validateToken(token: string, secret: string) {
 In SvelteKit we can use form actions to easily setup a form with a captcha:
 
 `routes/login/+page.svelte`
+
 ```html
 <script>
     import { Turnstile } from 'svelte-turnstile';
@@ -123,6 +123,7 @@ In SvelteKit we can use form actions to easily setup a form with a captcha:
 ```
 
 `routes/login/+page.server.js`
+
 ```js
 // Copy and paste the validateToken function from above here
 
@@ -130,8 +131,8 @@ export const actions = {
     default: async ({ request }) => {
         const data = await request.formData();
 
-        const token = data.get('cf-turnstile-response') // if you edited the formsField option change this
-        const SECRET_KEY = '...' // you should use $env module for secrets
+        const token = data.get('cf-turnstile-response'); // if you edited the formsField option change this
+        const SECRET_KEY = '...'; // you should use $env module for secrets
 
         const { success, error } = await validateToken(token, SECRET_KEY);
 
@@ -141,8 +142,8 @@ export const actions = {
             };
 
         // do something, the captcha is valid!
-    }
-}
+    },
+};
 ```
 
 # Resetting

--- a/README.md
+++ b/README.md
@@ -28,41 +28,46 @@ The only required prop is the `siteKey` which you can get from [adding a site he
 
 ## Props
 
-| Prop            | Type                                          | Description                                                                                    | Required |
-| --------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------- | -------- |
-| `siteKey`       | `string`                                      | sitekey for your website                                                                       | ✅       |
-| `theme`         | `'light' \| 'dark' \| 'auto'`                 | colour theme of the widget (defaults to `auto`)                                                |          |
-| `size`          | `'normal' \| 'compact'`                       | size of the widget (defaults to `normal`)                                                      |          |
-| `action`        | `string`                                      | A string that can be used to differentiate widgets, returned on validation                     |          |
-| `cData`         | `string`                                      | A string that can attach customer data to a challange, returned on validation                  |          |
-| `tabIndex`      | `number`                                      | Used for accessibility (defaults to `0`)                                                       |          |
-| `forms`         | `boolean`                                     | if true the response token will be a property on the form data (default `true`)                |          |
-| `formsField`    | `string`                                      | the `name` of the input which will appear on the form data (default `cf-turnstile-response`)   |          |
-| `retry`         | `'auto' \| 'never'`                           | should the widget automatically retry to obtain a token if it did not succeed (default `auto`) |          |
-| `retryInterval` | `number`                                      | if `retry` is true, this controls the time between attempts in milliseconds (default `8000`)   |          |
-| `language`      | `SupportedLanguage \| 'auto'`                 | the language turnstile should use (default `auto`)                                             |          |
-| `execution`     | `'render' \| 'execute'`                       | controls when to obtain the token of the widget (default `render`)                             |          |
-| `appearance`    | `'always' \| 'execute' \| 'interaction-only'` | controls when the widget is visible. (default `always`)                                        |          |
+| Prop                | Type                                          | Description                                                                                    | Required |
+| ------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------- | -------- |
+| `siteKey`           | `string`                                      | sitekey for your website                                                                       | ✅       |
+| `theme`             | `'light' \| 'dark' \| 'auto'`                 | colour theme of the widget (defaults to `auto`)                                                |          |
+| `size`              | `'normal' \| 'compact'`                       | size of the widget (defaults to `normal`)                                                      |          |
+| `action`            | `string`                                      | A string that can be used to differentiate widgets, returned on validation                     |          |
+| `cData`             | `string`                                      | A string that can attach customer data to a challange, returned on validation                  |          |
+| `tabIndex`          | `number`                                      | Used for accessibility (defaults to `0`)                                                       |          |
+| `responseField`     | `boolean`                                     | if true the response token will be a property on the form data (default `true`)                |          |
+| `responseFieldName` | `string`                                      | the `name` of the input which will appear on the form data (default `cf-turnstile-response`)   |          |
+| `retry`             | `'auto' \| 'never'`                           | should the widget automatically retry to obtain a token if it did not succeed (default `auto`) |          |
+| `retryInterval`     | `number`                                      | if `retry` is true, this controls the time between attempts in milliseconds (default `8000`)   |          |
+| `language`          | `SupportedLanguage \| 'auto'`                 | the language turnstile should use (default `auto`)                                             |          |
+| `execution`         | `'render' \| 'execute'`                       | controls when to obtain the token of the widget (default `render`)                             |          |
+| `appearance`        | `'always' \| 'execute' \| 'interaction-only'` | controls when the widget is visible. (default `always`)                                        |          |
 
 For more information about some of the props and a list of `SupportedLanguage`'s [checkout the Cloudflare Documentation](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configurations).
 
+### Deprecated Props
+
+-   `forms` renamed to `responseField`
+-   `formsField` renamed to `responseFieldName`
+
 ## Events
 
-| Event                         | Data                | Description                                                    |
-| ----------------------------- | ------------------- | -------------------------------------------------------------- |
-| `callback`                    | `{ token: string }` | Emitted when a user passes a challenge                         |
-| `error-callback`              | `{}`                | Emitted when a user fails verification                         |
-| `expired-callback`            | `{}`                | Emitted when a challenge expires and does not reset the widget |
-| `timeout-callback`            | `{}`                | Emitted when a challenge expires and does reset the widget     |
-| `before-interactive-callback` | `{}`                | Emitted before the challenge enters interactive mode           |
-| `after-interactive-callback`  | `{}`                | Emitted when the challenge has left interactive mode           |
-| `unsupported-callback`        | `{}`                | Emitted when a given client/browser is not supported           |
+| Event                | Data                | Description                                                    |
+| -------------------- | ------------------- | -------------------------------------------------------------- |
+| `callback`           | `{ token: string }` | Emitted when a user passes a challenge                         |
+| `error`              | `{ code: string }`  | Emitted when a user fails verification                         |
+| `expired`            | `{}`                | Emitted when a challenge expires and does not reset the widget |
+| `timeout`            | `{}`                | Emitted when a challenge expires and does reset the widget     |
+| `before-interactive` | `{}`                | Emitted before the challenge enters interactive mode           |
+| `after-interactive`  | `{}`                | Emitted when the challenge has left interactive mode           |
+| `unsupported`        | `{}`                | Emitted when a given client/browser is not supported           |
 
 # Validate CAPTCHA
 
 We need to validate the captcha token server side before we do any action on the server, this is to ensure no forgery occured. We can create a simple validate function:
 
-If you are using a HTML Form and POSTing to a server you can get the `cf-turnstile-response` (or what you configured it to using the `formsField` option) property to get the `token`, otherwise you can use the `on:turnstile-callback` event in svelte to keep track of the token and send it to your backend.
+If you are using a HTML Form and POSTing to a server you can get the `cf-turnstile-response` (or what you configured it to using the `responseFieldName` option) property to get the `token`, otherwise you can use the `on:callback` event in svelte to keep track of the token and send it to your backend.
 
 ```ts
 interface TokenValidateResponse {
@@ -114,7 +119,7 @@ In SvelteKit we can use form actions to easily setup a form with a captcha:
 </script>
 
 {#if form?.error}
-    <p>{form?.error}</p>
+<p>{form?.error}</p>
 {/if}
 
 <form method="POST" action="/login">
@@ -166,3 +171,14 @@ If you need to manually reset the widget, you can do so by binding to the `reset
 
 -   Join the [discord](https://discord.gg/2Vd4wAjJnm)<br>
 -   Create a issue on the [github](https://github.com/ghostdevv/svelte-turnstile)
+
+# Notable Changes
+
+Full Changelog: https://github.com/ghostdevv/svelte-turnstile/releases
+
+- Deprecate `forms` prop in favour of `responseField`
+- Deprecate `formsField` prop in favour of `responseFieldName`
+- Deprecate the `on:turnstile-callback` event in favour of `on:callback`
+- Deprecate the `on:turnstile-error` event in favour of `on:error`
+- Deprecate the `on:turnstile-timeout` event in favour of `on:timeout`
+- Deprecate the `on:turnstile-expired` event in favour of `on:expired`

--- a/package.json
+++ b/package.json
@@ -37,6 +37,12 @@
 		"url": "https://github.com/ghostdevv/svelte-turnstile/issues"
 	},
 	"author": "GHOST <ghostdevbusiness@gmail.com> (https://ghostdev.xyz)",
+	"contributors": [
+		{
+			"name": "Braden Wiggins",
+			"email": "braden@fracal-hq.com"
+		}
+	],
 	"exports": {
 		"./package.json": "./package.json",
 		".": {

--- a/package.json
+++ b/package.json
@@ -9,23 +9,23 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-auto": "2.1.0",
-		"@sveltejs/kit": "1.20.2",
-		"@sveltejs/package": "^2.1.0",
+		"@sveltejs/adapter-auto": "3.2.2",
+		"@sveltejs/kit": "2.5.18",
+		"@sveltejs/package": "^2.3.2",
+		"@sveltejs/vite-plugin-svelte": "^3.1.1",
 		"ghostsui": "^1.6.0",
-		"sass": "^1.63.6",
-		"svelte": "^3.59.2",
-		"svelte-check": "^3.4.4",
-		"svelte-preprocess": "^5.0.4",
-		"tslib": "^2.5.3",
-		"typescript": "^5.1.3",
-		"vite": "^4.3.9"
+		"sass": "^1.77.6",
+		"svelte": "^4.2.18",
+		"svelte-check": "^3.8.4",
+		"tslib": "^2.6.3",
+		"typescript": "^5.5.3",
+		"vite": "^5.3.2"
 	},
 	"peerDependencies": {
 		"svelte": "^3.58.0 || ^4.0.0"
 	},
 	"dependencies": {
-		"turnstile-types": "^1.2.0"
+		"turnstile-types": "^1.2.1"
 	},
 	"type": "module",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-turnstile",
-	"version": "0.5.1",
+	"version": "0.6.0",
 	"scripts": {
 		"dev": "vite dev",
 		"package": "svelte-kit sync && svelte-package",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"svelte": "^3.58.0 || ^4.0.0"
 	},
 	"dependencies": {
-		"turnstile-types": "^1.1.2"
+		"turnstile-types": "^1.2.0"
 	},
 	"type": "module",
 	"repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,48 +6,65 @@ settings:
 
 dependencies:
   turnstile-types:
-    specifier: ^1.2.0
-    version: 1.2.0
+    specifier: ^1.2.1
+    version: 1.2.1
 
 devDependencies:
   '@sveltejs/adapter-auto':
-    specifier: 2.1.0
-    version: 2.1.0(@sveltejs/kit@1.20.2)
+    specifier: 3.2.2
+    version: 3.2.2(@sveltejs/kit@2.5.18)
   '@sveltejs/kit':
-    specifier: 1.20.2
-    version: 1.20.2(svelte@3.59.2)(vite@4.3.9)
+    specifier: 2.5.18
+    version: 2.5.18(@sveltejs/vite-plugin-svelte@3.1.1)(svelte@4.2.18)(vite@5.3.2)
   '@sveltejs/package':
-    specifier: ^2.1.0
-    version: 2.1.0(svelte@3.59.2)(typescript@5.1.3)
+    specifier: ^2.3.2
+    version: 2.3.2(svelte@4.2.18)(typescript@5.5.3)
+  '@sveltejs/vite-plugin-svelte':
+    specifier: ^3.1.1
+    version: 3.1.1(svelte@4.2.18)(vite@5.3.2)
   ghostsui:
     specifier: ^1.6.0
     version: 1.6.0
   sass:
-    specifier: ^1.63.6
-    version: 1.63.6
+    specifier: ^1.77.6
+    version: 1.77.6
   svelte:
-    specifier: ^3.59.2
-    version: 3.59.2
+    specifier: ^4.2.18
+    version: 4.2.18
   svelte-check:
-    specifier: ^3.4.4
-    version: 3.4.4(sass@1.63.6)(svelte@3.59.2)
-  svelte-preprocess:
-    specifier: ^5.0.4
-    version: 5.0.4(sass@1.63.6)(svelte@3.59.2)(typescript@5.1.3)
+    specifier: ^3.8.4
+    version: 3.8.4(sass@1.77.6)(svelte@4.2.18)
   tslib:
-    specifier: ^2.5.3
-    version: 2.5.3
+    specifier: ^2.6.3
+    version: 2.6.3
   typescript:
-    specifier: ^5.1.3
-    version: 5.1.3
+    specifier: ^5.5.3
+    version: 5.5.3
   vite:
-    specifier: ^4.3.9
-    version: 4.3.9(sass@1.63.6)
+    specifier: ^5.3.2
+    version: 5.3.2(sass@1.77.6)
 
 packages:
 
-  /@esbuild/android-arm64@0.17.19:
-    resolution: {integrity: sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==}
+  /@ampproject/remapping@2.3.0:
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
+    dev: true
+
+  /@esbuild/aix-ppc64@0.21.5:
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.21.5:
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -55,8 +72,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm@0.17.19:
-    resolution: {integrity: sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==}
+  /@esbuild/android-arm@0.21.5:
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -64,8 +81,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-x64@0.17.19:
-    resolution: {integrity: sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==}
+  /@esbuild/android-x64@0.21.5:
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -73,8 +90,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.17.19:
-    resolution: {integrity: sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==}
+  /@esbuild/darwin-arm64@0.21.5:
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -82,8 +99,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-x64@0.17.19:
-    resolution: {integrity: sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==}
+  /@esbuild/darwin-x64@0.21.5:
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -91,8 +108,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.17.19:
-    resolution: {integrity: sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==}
+  /@esbuild/freebsd-arm64@0.21.5:
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -100,8 +117,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-x64@0.17.19:
-    resolution: {integrity: sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==}
+  /@esbuild/freebsd-x64@0.21.5:
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -109,8 +126,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm64@0.17.19:
-    resolution: {integrity: sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==}
+  /@esbuild/linux-arm64@0.21.5:
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -118,8 +135,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm@0.17.19:
-    resolution: {integrity: sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==}
+  /@esbuild/linux-arm@0.21.5:
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -127,8 +144,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ia32@0.17.19:
-    resolution: {integrity: sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==}
+  /@esbuild/linux-ia32@0.21.5:
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -136,8 +153,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-loong64@0.17.19:
-    resolution: {integrity: sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==}
+  /@esbuild/linux-loong64@0.21.5:
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -145,8 +162,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.17.19:
-    resolution: {integrity: sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==}
+  /@esbuild/linux-mips64el@0.21.5:
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -154,8 +171,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ppc64@0.17.19:
-    resolution: {integrity: sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==}
+  /@esbuild/linux-ppc64@0.21.5:
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -163,8 +180,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.17.19:
-    resolution: {integrity: sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==}
+  /@esbuild/linux-riscv64@0.21.5:
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -172,8 +189,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-s390x@0.17.19:
-    resolution: {integrity: sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==}
+  /@esbuild/linux-s390x@0.21.5:
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -181,8 +198,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-x64@0.17.19:
-    resolution: {integrity: sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==}
+  /@esbuild/linux-x64@0.21.5:
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -190,8 +207,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/netbsd-x64@0.17.19:
-    resolution: {integrity: sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==}
+  /@esbuild/netbsd-x64@0.21.5:
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -199,8 +216,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/openbsd-x64@0.17.19:
-    resolution: {integrity: sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==}
+  /@esbuild/openbsd-x64@0.21.5:
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -208,8 +225,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/sunos-x64@0.17.19:
-    resolution: {integrity: sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==}
+  /@esbuild/sunos-x64@0.21.5:
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -217,8 +234,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-arm64@0.17.19:
-    resolution: {integrity: sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==}
+  /@esbuild/win32-arm64@0.21.5:
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -226,8 +243,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-ia32@0.17.19:
-    resolution: {integrity: sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==}
+  /@esbuild/win32-ia32@0.21.5:
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -235,8 +252,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-x64@0.17.19:
-    resolution: {integrity: sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==}
+  /@esbuild/win32-x64@0.21.5:
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -244,146 +261,273 @@ packages:
     dev: true
     optional: true
 
-  /@jridgewell/resolve-uri@3.1.0:
-    resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
+  /@jridgewell/gen-mapping@0.3.5:
+    resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/set-array': 1.2.1
+      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/trace-mapping': 0.3.25
+    dev: true
+
+  /@jridgewell/resolve-uri@3.1.2:
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
     dev: true
 
-  /@jridgewell/sourcemap-codec@1.4.14:
-    resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
+  /@jridgewell/set-array@1.2.1:
+    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
+    engines: {node: '>=6.0.0'}
     dev: true
 
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
     dev: true
 
-  /@jridgewell/trace-mapping@0.3.18:
-    resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==}
+  /@jridgewell/trace-mapping@0.3.25:
+    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
     dependencies:
-      '@jridgewell/resolve-uri': 3.1.0
-      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
-  /@nodelib/fs.scandir@2.1.5:
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
-    engines: {node: '>= 8'}
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      run-parallel: 1.2.0
+  /@polka/url@1.0.0-next.25:
+    resolution: {integrity: sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==}
     dev: true
 
-  /@nodelib/fs.stat@2.0.5:
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
-    engines: {node: '>= 8'}
+  /@rollup/rollup-android-arm-eabi@4.18.0:
+    resolution: {integrity: sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
     dev: true
+    optional: true
 
-  /@nodelib/fs.walk@1.2.8:
-    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
-    engines: {node: '>= 8'}
-    dependencies:
-      '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.15.0
+  /@rollup/rollup-android-arm64@4.18.0:
+    resolution: {integrity: sha512-avCea0RAP03lTsDhEyfy+hpfr85KfyTctMADqHVhLAF3MlIkq83CP8UfAHUssgXTYd+6er6PaAhx/QGv4L1EiA==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
     dev: true
+    optional: true
 
-  /@polka/url@1.0.0-next.21:
-    resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
+  /@rollup/rollup-darwin-arm64@4.18.0:
+    resolution: {integrity: sha512-IWfdwU7KDSm07Ty0PuA/W2JYoZ4iTj3TUQjkVsO/6U+4I1jN5lcR71ZEvRh52sDOERdnNhhHU57UITXz5jC1/w==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
     dev: true
+    optional: true
 
-  /@sveltejs/adapter-auto@2.1.0(@sveltejs/kit@1.20.2):
-    resolution: {integrity: sha512-o2pZCfATFtA/Gw/BB0Xm7k4EYaekXxaPGER3xGSY3FvzFJGTlJlZjBseaXwYSM94lZ0HniOjTokN3cWaLX6fow==}
+  /@rollup/rollup-darwin-x64@4.18.0:
+    resolution: {integrity: sha512-n2LMsUz7Ynu7DoQrSQkBf8iNrjOGyPLrdSg802vk6XT3FtsgX6JbE8IHRvposskFm9SNxzkLYGSq9QdpLYpRNA==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-gnueabihf@4.18.0:
+    resolution: {integrity: sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-musleabihf@4.18.0:
+    resolution: {integrity: sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-gnu@4.18.0:
+    resolution: {integrity: sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-musl@4.18.0:
+    resolution: {integrity: sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-powerpc64le-gnu@4.18.0:
+    resolution: {integrity: sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-gnu@4.18.0:
+    resolution: {integrity: sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-s390x-gnu@4.18.0:
+    resolution: {integrity: sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-gnu@4.18.0:
+    resolution: {integrity: sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-musl@4.18.0:
+    resolution: {integrity: sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-arm64-msvc@4.18.0:
+    resolution: {integrity: sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-ia32-msvc@4.18.0:
+    resolution: {integrity: sha512-Txjh+IxBPbkUB9+SXZMpv+b/vnTEtFyfWZgJ6iyCmt2tdx0OF5WhFowLmnh8ENGNpfUlUZkdI//4IEmhwPieNg==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-msvc@4.18.0:
+    resolution: {integrity: sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@sveltejs/adapter-auto@3.2.2(@sveltejs/kit@2.5.18):
+    resolution: {integrity: sha512-Mso5xPCA8zgcKrv+QioVlqMZkyUQ5MjDJiEPuG/Z7cV/5tmwV7LmcVWk5tZ+H0NCOV1x12AsoSpt/CwFwuVXMA==}
     peerDependencies:
-      '@sveltejs/kit': ^1.0.0
+      '@sveltejs/kit': ^2.0.0
     dependencies:
-      '@sveltejs/kit': 1.20.2(svelte@3.59.2)(vite@4.3.9)
-      import-meta-resolve: 3.0.0
+      '@sveltejs/kit': 2.5.18(@sveltejs/vite-plugin-svelte@3.1.1)(svelte@4.2.18)(vite@5.3.2)
+      import-meta-resolve: 4.1.0
     dev: true
 
-  /@sveltejs/kit@1.20.2(svelte@3.59.2)(vite@4.3.9):
-    resolution: {integrity: sha512-MtR1i+HtmYWcRgtubw1GQqT/+CWXL/z24PegE0xYAdObbhdr7YtEfmoe705D/JZMtMmoPXrmSk4W0MfL5A3lYw==}
-    engines: {node: ^16.14 || >=18}
+  /@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.1)(svelte@4.2.18)(vite@5.3.2):
+    resolution: {integrity: sha512-+g06hvpVAnH7b4CDjhnTDgFWBKBiQJpuSmQeGYOuzbO3SC3tdYjRNlDCrafvDtKbGiT2uxY5Dn9qdEUGVZdWOQ==}
+    engines: {node: '>=18.13'}
     hasBin: true
     requiresBuild: true
     peerDependencies:
-      svelte: ^3.54.0 || ^4.0.0-next.0
-      vite: ^4.0.0
+      '@sveltejs/vite-plugin-svelte': ^3.0.0
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      vite: ^5.0.3
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.2(svelte@3.59.2)(vite@4.3.9)
-      '@types/cookie': 0.5.1
-      cookie: 0.5.0
-      devalue: 4.3.2
+      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@4.2.18)(vite@5.3.2)
+      '@types/cookie': 0.6.0
+      cookie: 0.6.0
+      devalue: 5.0.0
       esm-env: 1.0.0
+      import-meta-resolve: 4.1.0
       kleur: 4.1.5
-      magic-string: 0.30.0
-      mime: 3.0.0
+      magic-string: 0.30.10
+      mrmime: 2.0.0
       sade: 1.8.1
       set-cookie-parser: 2.6.0
-      sirv: 2.0.3
-      svelte: 3.59.2
+      sirv: 2.0.4
+      svelte: 4.2.18
       tiny-glob: 0.2.9
-      undici: 5.22.1
-      vite: 4.3.9(sass@1.63.6)
-    transitivePeerDependencies:
-      - supports-color
+      vite: 5.3.2(sass@1.77.6)
     dev: true
 
-  /@sveltejs/package@2.1.0(svelte@3.59.2)(typescript@5.1.3):
-    resolution: {integrity: sha512-c6PLH9G2YLQ48kqrS2XX422BrLNABBstSiapamchVJaQnOTXyJmUR8KmoCCySnzVy3PiYL6jg12UnoPmjW3SwA==}
+  /@sveltejs/package@2.3.2(svelte@4.2.18)(typescript@5.5.3):
+    resolution: {integrity: sha512-6M8/Te7iXRG7SiH92wugqfyoJpuepjn78L433LnXicUeMso9M/N4vdL9DPK3MfTkVVY4klhNRptVqme3p4oZWA==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
     peerDependencies:
-      svelte: ^3.44.0 || ^4.0.0
+      svelte: ^3.44.0 || ^4.0.0 || ^5.0.0-next.1
     dependencies:
-      chokidar: 3.5.3
+      chokidar: 3.6.0
       kleur: 4.1.5
       sade: 1.8.1
-      svelte: 3.59.2
-      svelte2tsx: 0.6.16(svelte@3.59.2)(typescript@5.1.3)
+      semver: 7.6.2
+      svelte: 4.2.18
+      svelte2tsx: 0.7.13(svelte@4.2.18)(typescript@5.5.3)
     transitivePeerDependencies:
       - typescript
     dev: true
 
-  /@sveltejs/vite-plugin-svelte-inspector@1.0.3(@sveltejs/vite-plugin-svelte@2.4.2)(svelte@3.59.2)(vite@4.3.9):
-    resolution: {integrity: sha512-Khdl5jmmPN6SUsVuqSXatKpQTMIifoQPDanaxC84m9JxIibWvSABJyHpyys0Z+1yYrxY5TTEQm+6elh0XCMaOA==}
-    engines: {node: ^14.18.0 || >= 16}
+  /@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.1)(svelte@4.2.18)(vite@5.3.2):
+    resolution: {integrity: sha512-9QX28IymvBlSCqsCll5t0kQVxipsfhFFL+L2t3nTWfXnddYwxBuAEtTtlaVQpRz9c37BhJjltSeY4AJSC03SSg==}
+    engines: {node: ^18.0.0 || >=20}
     peerDependencies:
-      '@sveltejs/vite-plugin-svelte': ^2.2.0
-      svelte: ^3.54.0 || ^4.0.0
-      vite: ^4.0.0
+      '@sveltejs/vite-plugin-svelte': ^3.0.0
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      vite: ^5.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.2(svelte@3.59.2)(vite@4.3.9)
-      debug: 4.3.4
-      svelte: 3.59.2
-      vite: 4.3.9(sass@1.63.6)
+      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@4.2.18)(vite@5.3.2)
+      debug: 4.3.5
+      svelte: 4.2.18
+      vite: 5.3.2(sass@1.77.6)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@sveltejs/vite-plugin-svelte@2.4.2(svelte@3.59.2)(vite@4.3.9):
-    resolution: {integrity: sha512-ePfcC48ftMKhkT0OFGdOyycYKnnkT6i/buzey+vHRTR/JpQvuPzzhf1PtKqCDQfJRgoPSN2vscXs6gLigx/zGw==}
-    engines: {node: ^14.18.0 || >= 16}
+  /@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.18)(vite@5.3.2):
+    resolution: {integrity: sha512-rimpFEAboBBHIlzISibg94iP09k/KYdHgVhJlcsTfn7KMBhc70jFX/GRWkRdFCc2fdnk+4+Bdfej23cMDnJS6A==}
+    engines: {node: ^18.0.0 || >=20}
     peerDependencies:
-      svelte: ^3.54.0 || ^4.0.0
-      vite: ^4.0.0
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      vite: ^5.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 1.0.3(@sveltejs/vite-plugin-svelte@2.4.2)(svelte@3.59.2)(vite@4.3.9)
-      debug: 4.3.4
+      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.1)(svelte@4.2.18)(vite@5.3.2)
+      debug: 4.3.5
       deepmerge: 4.3.1
       kleur: 4.1.5
-      magic-string: 0.30.0
-      svelte: 3.59.2
-      svelte-hmr: 0.15.2(svelte@3.59.2)
-      vite: 4.3.9(sass@1.63.6)
-      vitefu: 0.2.4(vite@4.3.9)
+      magic-string: 0.30.10
+      svelte: 4.2.18
+      svelte-hmr: 0.16.0(svelte@4.2.18)
+      vite: 5.3.2(sass@1.77.6)
+      vitefu: 0.2.5(vite@5.3.2)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@types/cookie@0.5.1:
-    resolution: {integrity: sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==}
+  /@types/cookie@0.6.0:
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
     dev: true
 
-  /@types/pug@2.0.6:
-    resolution: {integrity: sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==}
+  /@types/estree@1.0.5:
+    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
+    dev: true
+
+  /@types/pug@2.0.10:
+    resolution: {integrity: sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA==}
+    dev: true
+
+  /acorn@8.12.0:
+    resolution: {integrity: sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
     dev: true
 
   /anymatch@3.1.3:
@@ -394,12 +538,24 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+    dependencies:
+      dequal: 2.0.3
+    dev: true
+
+  /axobject-query@4.0.0:
+    resolution: {integrity: sha512-+60uv1hiVFhHZeO+Lz0RYzsVHy5Wr1ayX0mwda9KPDVLNJgZ1T9Ny7VmFbLDzxsH0D87I86vgj3gFrjTJUYznw==}
+    dependencies:
+      dequal: 2.0.3
+    dev: true
+
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
 
-  /binary-extensions@2.2.0:
-    resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
+  /binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
     dev: true
 
@@ -410,55 +566,62 @@ packages:
       concat-map: 0.0.1
     dev: true
 
-  /braces@3.0.2:
-    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+  /braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
     dependencies:
-      fill-range: 7.0.1
+      fill-range: 7.1.1
     dev: true
 
-  /buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+  /buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
     dev: true
 
-  /busboy@1.6.0:
-    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
-    engines: {node: '>=10.16.0'}
-    dependencies:
-      streamsearch: 1.1.0
-    dev: true
-
-  /callsites@3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /chokidar@3.5.3:
-    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
+  /chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
     dependencies:
       anymatch: 3.1.3
-      braces: 3.0.2
+      braces: 3.0.3
       glob-parent: 5.1.2
       is-binary-path: 2.1.0
       is-glob: 4.0.3
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
+    dev: true
+
+  /code-red@1.0.4:
+    resolution: {integrity: sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+      '@types/estree': 1.0.5
+      acorn: 8.12.0
+      estree-walker: 3.0.3
+      periscopic: 3.1.0
     dev: true
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
 
-  /cookie@0.5.0:
-    resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
+  /cookie@0.6.0:
+    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
     dev: true
 
-  /debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+  /css-tree@2.3.1:
+    resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+    dependencies:
+      mdn-data: 2.0.30
+      source-map-js: 1.2.0
+    dev: true
+
+  /debug@4.3.5:
+    resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -478,72 +641,67 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+    dev: true
+
   /detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
     dev: true
 
-  /devalue@4.3.2:
-    resolution: {integrity: sha512-KqFl6pOgOW+Y6wJgu80rHpo2/3H07vr8ntR9rkkFIRETewbf5GaYYcakYfiKz89K+sLsuPkQIZaXDMjUObZwWg==}
+  /devalue@5.0.0:
+    resolution: {integrity: sha512-gO+/OMXF7488D+u3ue+G7Y4AA3ZmUnB3eHJXmBTgNHvr4ZNzl36A0ZtG+XCRNYCkYx/bFmw4qtkoFLa+wSrwAA==}
     dev: true
 
   /es6-promise@3.3.1:
     resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
     dev: true
 
-  /esbuild@0.17.19:
-    resolution: {integrity: sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==}
+  /esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@esbuild/android-arm': 0.17.19
-      '@esbuild/android-arm64': 0.17.19
-      '@esbuild/android-x64': 0.17.19
-      '@esbuild/darwin-arm64': 0.17.19
-      '@esbuild/darwin-x64': 0.17.19
-      '@esbuild/freebsd-arm64': 0.17.19
-      '@esbuild/freebsd-x64': 0.17.19
-      '@esbuild/linux-arm': 0.17.19
-      '@esbuild/linux-arm64': 0.17.19
-      '@esbuild/linux-ia32': 0.17.19
-      '@esbuild/linux-loong64': 0.17.19
-      '@esbuild/linux-mips64el': 0.17.19
-      '@esbuild/linux-ppc64': 0.17.19
-      '@esbuild/linux-riscv64': 0.17.19
-      '@esbuild/linux-s390x': 0.17.19
-      '@esbuild/linux-x64': 0.17.19
-      '@esbuild/netbsd-x64': 0.17.19
-      '@esbuild/openbsd-x64': 0.17.19
-      '@esbuild/sunos-x64': 0.17.19
-      '@esbuild/win32-arm64': 0.17.19
-      '@esbuild/win32-ia32': 0.17.19
-      '@esbuild/win32-x64': 0.17.19
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
     dev: true
 
   /esm-env@1.0.0:
     resolution: {integrity: sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==}
     dev: true
 
-  /fast-glob@3.2.12:
-    resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
-    engines: {node: '>=8.6.0'}
+  /estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
     dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.5
+      '@types/estree': 1.0.5
     dev: true
 
-  /fastq@1.15.0:
-    resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
-    dependencies:
-      reusify: 1.0.4
-    dev: true
-
-  /fill-range@7.0.1:
-    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+  /fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
@@ -553,8 +711,8 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -577,6 +735,7 @@ packages:
 
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -604,24 +763,17 @@ packages:
       rfs: 9.0.6
     dev: true
 
-  /immutable@4.3.0:
-    resolution: {integrity: sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==}
+  /immutable@4.3.6:
+    resolution: {integrity: sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==}
     dev: true
 
-  /import-fresh@3.3.0:
-    resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
-    engines: {node: '>=6'}
-    dependencies:
-      parent-module: 1.0.1
-      resolve-from: 4.0.0
-    dev: true
-
-  /import-meta-resolve@3.0.0:
-    resolution: {integrity: sha512-4IwhLhNNA8yy445rPjD/lWh++7hMDOml2eHtd58eG7h+qK3EryMuuRbsHGPikCoAgIkkDnckKfWSk2iDla/ejg==}
+  /import-meta-resolve@4.1.0:
+    resolution: {integrity: sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==}
     dev: true
 
   /inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
@@ -635,7 +787,7 @@ packages:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
     dependencies:
-      binary-extensions: 2.2.0
+      binary-extensions: 2.3.0
     dev: true
 
   /is-extglob@2.1.1:
@@ -655,48 +807,35 @@ packages:
     engines: {node: '>=0.12.0'}
     dev: true
 
+  /is-reference@3.0.2:
+    resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
+    dependencies:
+      '@types/estree': 1.0.5
+    dev: true
+
   /kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
     dev: true
 
+  /locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
+    dev: true
+
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.3
     dev: true
 
-  /magic-string@0.27.0:
-    resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
-    engines: {node: '>=12'}
+  /magic-string@0.30.10:
+    resolution: {integrity: sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
-  /magic-string@0.30.0:
-    resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
-
-  /merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
-    dev: true
-
-  /micromatch@4.0.5:
-    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
-    engines: {node: '>=8.6'}
-    dependencies:
-      braces: 3.0.2
-      picomatch: 2.3.1
-    dev: true
-
-  /mime@3.0.0:
-    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
+  /mdn-data@2.0.30:
+    resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
     dev: true
 
   /min-indent@1.0.1:
@@ -726,8 +865,8 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /mrmime@1.0.1:
-    resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
+  /mrmime@2.0.0:
+    resolution: {integrity: sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==}
     engines: {node: '>=10'}
     dev: true
 
@@ -735,8 +874,8 @@ packages:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
 
-  /nanoid@3.3.6:
-    resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
+  /nanoid@3.3.7:
+    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: true
@@ -745,7 +884,7 @@ packages:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.5.3
+      tslib: 2.6.3
     dev: true
 
   /normalize-path@3.0.0:
@@ -759,18 +898,11 @@ packages:
       wrappy: 1.0.2
     dev: true
 
-  /parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
-    engines: {node: '>=6'}
-    dependencies:
-      callsites: 3.1.0
-    dev: true
-
   /pascal-case@3.1.2:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.3
+      tslib: 2.6.3
     dev: true
 
   /path-is-absolute@1.0.1:
@@ -778,8 +910,16 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /picocolors@1.0.0:
-    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+  /periscopic@3.1.0:
+    resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
+    dependencies:
+      '@types/estree': 1.0.5
+      estree-walker: 3.0.3
+      is-reference: 3.0.2
+    dev: true
+
+  /picocolors@1.0.1:
+    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
     dev: true
 
   /picomatch@2.3.1:
@@ -791,17 +931,13 @@ packages:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
     dev: true
 
-  /postcss@8.4.24:
-    resolution: {integrity: sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==}
+  /postcss@8.4.39:
+    resolution: {integrity: sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.6
-      picocolors: 1.0.0
-      source-map-js: 1.0.2
-    dev: true
-
-  /queue-microtask@1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+      nanoid: 3.3.7
+      picocolors: 1.0.1
+      source-map-js: 1.2.0
     dev: true
 
   /readdirp@3.6.0:
@@ -809,16 +945,6 @@ packages:
     engines: {node: '>=8.10.0'}
     dependencies:
       picomatch: 2.3.1
-    dev: true
-
-  /resolve-from@4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /reusify@1.0.4:
-    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
     dev: true
 
   /rfs@9.0.6:
@@ -830,23 +956,36 @@ packages:
 
   /rimraf@2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
     dependencies:
       glob: 7.2.3
     dev: true
 
-  /rollup@3.25.2:
-    resolution: {integrity: sha512-VLnkxZMDr3jpxgtmS8pQZ0UvhslmF4ADq/9w4erkctbgjCqLW9oa89fJuXEs4ZmgyoF7Dm8rMDKSS5b5u2hHUg==}
-    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+  /rollup@4.18.0:
+    resolution: {integrity: sha512-QmJz14PX3rzbJCN1SG4Xe/bAAX2a6NpCP8ab2vfu2GiUr8AQcr2nCV/oEO3yneFarB67zk8ShlIyWb2LGTb3Sg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
-  /run-parallel@1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
-      queue-microtask: 1.2.3
+      '@types/estree': 1.0.5
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.18.0
+      '@rollup/rollup-android-arm64': 4.18.0
+      '@rollup/rollup-darwin-arm64': 4.18.0
+      '@rollup/rollup-darwin-x64': 4.18.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.18.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.18.0
+      '@rollup/rollup-linux-arm64-gnu': 4.18.0
+      '@rollup/rollup-linux-arm64-musl': 4.18.0
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.18.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.18.0
+      '@rollup/rollup-linux-s390x-gnu': 4.18.0
+      '@rollup/rollup-linux-x64-gnu': 4.18.0
+      '@rollup/rollup-linux-x64-musl': 4.18.0
+      '@rollup/rollup-win32-arm64-msvc': 4.18.0
+      '@rollup/rollup-win32-ia32-msvc': 4.18.0
+      '@rollup/rollup-win32-x64-msvc': 4.18.0
+      fsevents: 2.3.3
     dev: true
 
   /sade@1.8.1:
@@ -869,47 +1008,48 @@ packages:
     resolution: {integrity: sha512-yxHIGddIE+HPvS86Y2imuu/J4LZmss0K9/Dpos38gAC21ThbZLwE4PeA/2mN3ZLH3gXhHxBtjxf6Oi1GAIrMag==}
     dev: true
 
-  /sass@1.63.6:
-    resolution: {integrity: sha512-MJuxGMHzaOW7ipp+1KdELtqKbfAWbH7OLIdoSMnVe3EXPMTmxTmlaZDCTsgIpPCs3w99lLo9/zDKkOrJuT5byw==}
+  /sass@1.77.6:
+    resolution: {integrity: sha512-ByXE1oLD79GVq9Ht1PeHWCPMPB8XHpBuz1r85oByKHjZY6qV6rWnQovQzXJXuQ/XyE1Oj3iPk3lo28uzaRA2/Q==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
-      chokidar: 3.5.3
-      immutable: 4.3.0
-      source-map-js: 1.0.2
+      chokidar: 3.6.0
+      immutable: 4.3.6
+      source-map-js: 1.2.0
+    dev: true
+
+  /semver@7.6.2:
+    resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
+    engines: {node: '>=10'}
+    hasBin: true
     dev: true
 
   /set-cookie-parser@2.6.0:
     resolution: {integrity: sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==}
     dev: true
 
-  /sirv@2.0.3:
-    resolution: {integrity: sha512-O9jm9BsID1P+0HOi81VpXPoDxYP374pkOLzACAoyUQ/3OUVndNpsz6wMnY2z+yOxzbllCKZrM+9QrWsv4THnyA==}
+  /sirv@2.0.4:
+    resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
     engines: {node: '>= 10'}
     dependencies:
-      '@polka/url': 1.0.0-next.21
-      mrmime: 1.0.1
+      '@polka/url': 1.0.0-next.25
+      mrmime: 2.0.0
       totalist: 3.0.1
     dev: true
 
-  /sorcery@0.11.0:
-    resolution: {integrity: sha512-J69LQ22xrQB1cIFJhPfgtLuI6BpWRiWu1Y3vSsIwK/eAScqJxd/+CJlUuHQRdX2C9NGFamq+KqNywGgaThwfHw==}
+  /sorcery@0.11.1:
+    resolution: {integrity: sha512-o7npfeJE6wi6J9l0/5LKshFzZ2rMatRiCDwYeDQaOzqdzRJwALhX7mk/A/ecg6wjMu7wdZbmXfD2S/vpOg0bdQ==}
     hasBin: true
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
-      buffer-crc32: 0.2.13
+      buffer-crc32: 1.0.0
       minimist: 1.2.8
       sander: 0.5.1
     dev: true
 
-  /source-map-js@1.0.2:
-    resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
+  /source-map-js@1.2.0:
+    resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
     engines: {node: '>=0.10.0'}
-    dev: true
-
-  /streamsearch@1.1.0:
-    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
-    engines: {node: '>=10.0.0'}
     dev: true
 
   /strip-indent@3.0.0:
@@ -919,21 +1059,19 @@ packages:
       min-indent: 1.0.1
     dev: true
 
-  /svelte-check@3.4.4(sass@1.63.6)(svelte@3.59.2):
-    resolution: {integrity: sha512-Uys9+R65cj8TmP8f5UpS7B2xKpNLYNxEWJsA5ZoKcWq/uwvABFF7xS6iPQGLoa7hxz0DS6xU60YFpmq06E4JxA==}
+  /svelte-check@3.8.4(sass@1.77.6)(svelte@4.2.18):
+    resolution: {integrity: sha512-61aHMkdinWyH8BkkTX9jPLYxYzaAAz/FK/VQqdr2FiCQQ/q04WCwDlpGbHff1GdrMYTmW8chlTFvRWL9k0A8vg==}
     hasBin: true
     peerDependencies:
-      svelte: ^3.55.0 || ^4.0.0-next.0 || ^4.0.0
+      svelte: ^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.18
-      chokidar: 3.5.3
-      fast-glob: 3.2.12
-      import-fresh: 3.3.0
-      picocolors: 1.0.0
+      '@jridgewell/trace-mapping': 0.3.25
+      chokidar: 3.6.0
+      picocolors: 1.0.1
       sade: 1.8.1
-      svelte: 3.59.2
-      svelte-preprocess: 5.0.4(sass@1.63.6)(svelte@3.59.2)(typescript@5.1.3)
-      typescript: 5.1.3
+      svelte: 4.2.18
+      svelte-preprocess: 5.1.4(sass@1.77.6)(svelte@4.2.18)(typescript@5.5.3)
+      typescript: 5.5.3
     transitivePeerDependencies:
       - '@babel/core'
       - coffeescript
@@ -946,30 +1084,30 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-hmr@0.15.2(svelte@3.59.2):
-    resolution: {integrity: sha512-q/bAruCvFLwvNbeE1x3n37TYFb3mTBJ6TrCq6p2CoFbSTNhDE9oAtEfpy+wmc9So8AG0Tja+X0/mJzX9tSfvIg==}
+  /svelte-hmr@0.16.0(svelte@4.2.18):
+    resolution: {integrity: sha512-Gyc7cOS3VJzLlfj7wKS0ZnzDVdv3Pn2IuVeJPk9m2skfhcu5bq3wtIZyQGggr7/Iim5rH5cncyQft/kRLupcnA==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
-      svelte: ^3.19.0 || ^4.0.0-next.0
+      svelte: ^3.19.0 || ^4.0.0
     dependencies:
-      svelte: 3.59.2
+      svelte: 4.2.18
     dev: true
 
-  /svelte-preprocess@5.0.4(sass@1.63.6)(svelte@3.59.2)(typescript@5.1.3):
-    resolution: {integrity: sha512-ABia2QegosxOGsVlsSBJvoWeXy1wUKSfF7SWJdTjLAbx/Y3SrVevvvbFNQqrSJw89+lNSsM58SipmZJ5SRi5iw==}
-    engines: {node: '>= 14.10.0'}
+  /svelte-preprocess@5.1.4(sass@1.77.6)(svelte@4.2.18)(typescript@5.5.3):
+    resolution: {integrity: sha512-IvnbQ6D6Ao3Gg6ftiM5tdbR6aAETwjhHV+UKGf5bHGYR69RQvF1ho0JKPcbUON4vy4R7zom13jPjgdOWCQ5hDA==}
+    engines: {node: '>= 16.0.0'}
     requiresBuild: true
     peerDependencies:
       '@babel/core': ^7.10.2
       coffeescript: ^2.5.1
       less: ^3.11.3 || ^4.0.0
       postcss: ^7 || ^8
-      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0
+      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
       pug: ^3.0.0
       sass: ^1.26.8
       stylus: ^0.55.0
       sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
-      svelte: ^3.23.0 || ^4.0.0-next.0 || ^4.0.0
+      svelte: ^3.23.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0
       typescript: '>=3.9.5 || ^4.0.0 || ^5.0.0'
     peerDependenciesMeta:
       '@babel/core':
@@ -993,31 +1131,46 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@types/pug': 2.0.6
+      '@types/pug': 2.0.10
       detect-indent: 6.1.0
-      magic-string: 0.27.0
-      sass: 1.63.6
-      sorcery: 0.11.0
+      magic-string: 0.30.10
+      sass: 1.77.6
+      sorcery: 0.11.1
       strip-indent: 3.0.0
-      svelte: 3.59.2
-      typescript: 5.1.3
+      svelte: 4.2.18
+      typescript: 5.5.3
     dev: true
 
-  /svelte2tsx@0.6.16(svelte@3.59.2)(typescript@5.1.3):
-    resolution: {integrity: sha512-AX2iYEvQdd4tq5BokRdOOA0N/nD37ZnhXAomrAG9EEGl2cjkvoQUwe1Aluo6FSzA684WJjhxW+1ZXmveCmvDrA==}
+  /svelte2tsx@0.7.13(svelte@4.2.18)(typescript@5.5.3):
+    resolution: {integrity: sha512-aObZ93/kGAiLXA/I/kP+x9FriZM+GboB/ReOIGmLNbVGEd2xC+aTCppm3mk1cc9I/z60VQf7b2QDxC3jOXu3yw==}
     peerDependencies:
-      svelte: ^3.55 || ^4.0.0-next.0 || ^4.0
+      svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 3.59.2
-      typescript: 5.1.3
+      svelte: 4.2.18
+      typescript: 5.5.3
     dev: true
 
-  /svelte@3.59.2:
-    resolution: {integrity: sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==}
-    engines: {node: '>= 8'}
+  /svelte@4.2.18:
+    resolution: {integrity: sha512-d0FdzYIiAePqRJEb90WlJDkjUEx42xhivxN8muUBmfZnP+tzUgz12DJ2hRJi8sIHCME7jeK1PTMgKPSfTd8JrA==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/trace-mapping': 0.3.25
+      '@types/estree': 1.0.5
+      acorn: 8.12.0
+      aria-query: 5.3.0
+      axobject-query: 4.0.0
+      code-red: 1.0.4
+      css-tree: 2.3.1
+      estree-walker: 3.0.3
+      is-reference: 3.0.2
+      locate-character: 3.0.0
+      magic-string: 0.30.10
+      periscopic: 3.1.0
     dev: true
 
   /tiny-glob@0.2.9:
@@ -1039,34 +1192,28 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /tslib@2.5.3:
-    resolution: {integrity: sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==}
+  /tslib@2.6.3:
+    resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
     dev: true
 
-  /turnstile-types@1.2.0:
-    resolution: {integrity: sha512-cTtNEtCYpcXeXR5AOD0YR0xZpXk1iZeTOuXT5vAGNowGGdgapC+k6m/lOVSkmDOUopZmPtmu311XeULIro4gUA==}
+  /turnstile-types@1.2.1:
+    resolution: {integrity: sha512-PZFcUDFvPvmmwb885JA/N+8Pg5xNWw/UGMABRb/vI9P8cZ4pLDCpBDzgw7oKQ67DYvboTxNhfTAu93gjX4uNbQ==}
     dev: false
 
-  /typescript@5.1.3:
-    resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}
+  /typescript@5.5.3:
+    resolution: {integrity: sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
 
-  /undici@5.22.1:
-    resolution: {integrity: sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==}
-    engines: {node: '>=14.0'}
-    dependencies:
-      busboy: 1.6.0
-    dev: true
-
-  /vite@4.3.9(sass@1.63.6):
-    resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
+  /vite@5.3.2(sass@1.77.6):
+    resolution: {integrity: sha512-6lA7OBHBlXUxiJxbO5aAY2fsHHzDr1q7DvXYnyZycRs2Dz+dXBWuhpWHvmljTRTpQC2uvGmUFFkSHF2vGo90MA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': '>= 14'
+      '@types/node': ^18.0.0 || >=20.0.0
       less: '*'
+      lightningcss: ^1.21.0
       sass: '*'
       stylus: '*'
       sugarss: '*'
@@ -1075,6 +1222,8 @@ packages:
       '@types/node':
         optional: true
       less:
+        optional: true
+      lightningcss:
         optional: true
       sass:
         optional: true
@@ -1085,23 +1234,23 @@ packages:
       terser:
         optional: true
     dependencies:
-      esbuild: 0.17.19
-      postcss: 8.4.24
-      rollup: 3.25.2
-      sass: 1.63.6
+      esbuild: 0.21.5
+      postcss: 8.4.39
+      rollup: 4.18.0
+      sass: 1.77.6
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
-  /vitefu@0.2.4(vite@4.3.9):
-    resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
+  /vitefu@0.2.5(vite@5.3.2):
+    resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
     peerDependencies:
-      vite: ^3.0.0 || ^4.0.0
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0
     peerDependenciesMeta:
       vite:
         optional: true
     dependencies:
-      vite: 4.3.9(sass@1.63.6)
+      vite: 5.3.2(sass@1.77.6)
     dev: true
 
   /wrappy@1.0.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   turnstile-types:
-    specifier: ^1.1.2
-    version: 1.1.2
+    specifier: ^1.2.0
+    version: 1.2.0
 
 devDependencies:
   '@sveltejs/adapter-auto':
@@ -1043,8 +1043,8 @@ packages:
     resolution: {integrity: sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==}
     dev: true
 
-  /turnstile-types@1.1.2:
-    resolution: {integrity: sha512-MJXbAeRPpORqPViZbHrpu8LWOHv1dp9i5GYSfoedu7GUmkUZpHWlAVLCFAhWlpRA5PQLBRworOGCEu4o6Ks7Zw==}
+  /turnstile-types@1.2.0:
+    resolution: {integrity: sha512-cTtNEtCYpcXeXR5AOD0YR0xZpXk1iZeTOuXT5vAGNowGGdgapC+k6m/lOVSkmDOUopZmPtmu311XeULIro4gUA==}
     dev: false
 
   /typescript@5.1.3:

--- a/src/lib/Turnstile.svelte
+++ b/src/lib/Turnstile.svelte
@@ -7,14 +7,14 @@
 </script>
 
 <script lang="ts">
+    import { createEventDispatcher, onMount } from 'svelte';
+    import type { Action } from 'svelte/action';
+    import type { Events } from './types';
     import type {
         RenderParameters,
         TurnstileObject,
         WidgetId,
     } from 'turnstile-types';
-    import { createEventDispatcher, onMount } from 'svelte';
-    import type { Action } from 'svelte/action';
-    import type { Events } from './types';
 
     const dispatch = createEventDispatcher<Events>();
 
@@ -171,6 +171,25 @@
                 dispatch('callback', { token });
                 dispatch('turnstile-callback', { token });
             },
+            'error-callback': (code) => {
+                dispatch('error', { code });
+                dispatch('turnstile-error', { code });
+            },
+            'timeout-callback': () => {
+                dispatch('timeout', {});
+                dispatch('turnstile-timeout', {});
+            },
+            'expired-callback': () => {
+                dispatch('expired', {});
+                dispatch('turnstile-expired', {});
+            },
+            'before-interactive-callback': () => {
+                dispatch('before-interactive', {});
+            },
+            'after-interactive-callback': () => {
+                dispatch('after-interactive', {});
+            },
+            'unsupported-callback': () => dispatch('unsupported', {}),
             'response-field-name': formsField || responseFieldName,
             'response-field': forms ?? responseField ?? true,
             'refresh-expired': refreshExpired,
@@ -184,7 +203,7 @@
             theme,
             cData,
             size,
-        })!;
+        });
 
         widgetId = id;
 

--- a/src/lib/Turnstile.svelte
+++ b/src/lib/Turnstile.svelte
@@ -1,85 +1,212 @@
+<script lang="ts" context="module">
+    declare global {
+        interface Window {
+            turnstile: TurnstileObject;
+        }
+    }
+</script>
+
 <script lang="ts">
-    import type { Option, TurnstileSize, TurnstileTheme } from './types.d';
-    import type { SupportedLanguages } from 'turnstile-types';
-    import { createEventDispatcher, onMount } from 'svelte';
+    import type { RenderOptions, TurnstileObject, WidgetId } from './types.d';
     import type { Action } from 'svelte/action';
 
-    const dispatch = createEventDispatcher<{
-        'turnstile-callback': { token: string };
-        'turnstile-error': {};
-        'turnstile-expired': {};
-        'turnstile-timeout': {};
-    }>();
+    import { createEventDispatcher, onMount } from 'svelte';
 
-    let loaded = hasTurnstile();
+    const dispatch = createEventDispatcher<
+        {
+            /**
+             * Callback function invoked upon successful challenge completion.
+             * - Data Attribute - `data-callback`
+             * @param token - The token passed upon successful challenge.
+             */
+            callback: { token: string };
+        } & typeof events
+    >();
+
+    let loaded = windowHasTurnstile();
     let mounted = false;
 
-    let widgetId: string;
+    /**
+     * Represents a rendered Turnstile widget.  Used to identify a specific widget when calling
+     * Turnstile methods.
+     */
+    let widgetId: WidgetId;
 
-    export let siteKey: string;
+    /**
+     * Turnstile is Cloudflare’s smart CAPTCHA alternative. It can be embedded into any website
+     * without sending traffic through Cloudflare and works without showing visitors a CAPTCHA.
+     * @see https://developers.cloudflare.com/turnstile
+     */
+    export let turnstile: TurnstileObject | null = null;
+    $: turnstile =
+        windowHasTurnstile() && window.turnstile ? window.turnstile : null;
 
-    export let appearance: Option<'appearance'> = 'always';
-    export let language: SupportedLanguages | 'auto' = 'auto';
-    export let formsField: string = 'cf-turnstile-response';
-    export let execution: Option<'execution'> = 'render';
-    export let action: string | undefined = undefined;
-    export let cData: string | undefined = undefined;
-    export let retryInterval: number | undefined = 8000;
-    export let retry: Option<'retry'> = 'auto';
-    export let theme: TurnstileTheme = 'auto';
-    export let size: TurnstileSize = 'normal';
-    export let forms = true;
+    /**
+     * Every widget has a sitekey. This sitekey is associated with the corresponding
+     * widget configuration and is created upon the widget creation.
+     * - Data Attribute - `data-sitekey`
+     */
+    export let siteKey: RenderOptions['sitekey'];
+
+    /**
+     * Controls when the widget is visible:
+     * - `"always"` - The widget is visible at all times.
+     * - `"execute"` - The widget is visible only after the challenge begins.
+     * - `"interaction-only"` - The widget is visible only when an interaction is required.
+     *
+     * If a widget is visible, its appearance can be controlled via the `appearance` parameter.
+     * - Data Attribute - `data-appearance`
+     * @see
+     * [appearance-modes](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#appearance-modes)
+     */
+    export let appearance: RenderOptions['appearance'] = 'always';
+
+    /**
+     * Language to display, either `"auto"` or an ISO 639-1 two-letter language code.
+     * - Data Attribute - `data-language`
+     * @see [language support FAQ](https://developers.cloudflare.com/turnstile/frequently-asked-questions/#what-languages-does-turnstile-support)
+     */
+    export let language: RenderOptions['language'] = 'auto' as const;
+
+    /**
+     * Execution controls when to obtain the token of the widget and can be on `"render"` (default) or on `"execute"`.
+     * - Data Attribute - `data-execution`
+     * @defaultValue "render"
+     * @see [Execution modes](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#execution-modes)
+     */
+    export let execution: RenderOptions['execution'] = 'render';
+
+    /**
+     * A customer value that can be used to differentiate widgets under the same
+     * sitekey in analytics and which is returned upon validation. This can only
+     * contain up to 32 alphanumeric characters including `_` and `-`.
+     * - Data Attribute - `data-action`
+     */
+    export let action: RenderOptions['action'] = undefined;
+
+    /**
+     * A customer payload that can be used to attach customer data to the challenge
+     * throughout its issuance and which is returned upon validation. This can only
+     * contain up to 255 alphanumeric characters including `_` and `-`.
+     * - Data Attribute - `data-cdata`
+     */
+    export let cData: RenderOptions['cData'] =
+        undefined as any as RenderOptions['cData'];
+
+    /**
+     * Time between retry attempts in milliseconds. Value must be between `0` and `900000`
+     * (15 minutes). Only applies when `retry` is set to `auto`.
+     * - Data Attribute - `data-retry-interval`
+     * @defaultValue 8000
+     */
+    export let retryInterval: RenderOptions['retry-interval'] = 8000;
+
+    /**
+     * Automatically retry upon failure to obtain a token or never retry.
+     * - Data Attribute - `data-retry`
+     * @defaultValue "auto"
+     */
+    export let retry: RenderOptions['retry'] = 'auto';
+
+    /**
+     * Controls the behavior when the token of a Turnstile widget has expired.
+     * Can be 'auto', 'manual', or 'never'.
+     * - Data Attribute - `data-refresh-expired`
+     * @defaultValue "auto"
+     */
+    export let refreshExpired: RenderOptions['refresh-expired'] = 'auto';
+
+    /**
+     * The widget theme. Can be `"light"`, `"dark"`, or `"auto"`.
+     * - Data Attribute - `data-theme`
+     */
+    export let theme: RenderOptions['theme'] = 'auto';
+
+    /**
+     * The widget size. Can be 'normal' or 'compact'.
+     * - Data Attribute - `data-size`
+     * @defaultValue "normal"
+     */
+    export let size: RenderOptions['size'] = 'normal';
+
+    /**
+     * The tabindex of Turnstile's iframe for accessibility purposes.
+     * - Data Attribute - `data-tabindex`
+     * @defaultValue 0
+     */
     export let tabIndex = 0;
 
-    onMount(() => {
-        mounted = true;
+    /**
+     * Controls if an input element with the response token is created.
+     * - Data Attribute - `data-response-field`
+     * @defaultValue true
+     */
+    export let responseField: RenderOptions['response-field'] = true;
 
-        return () => {
-            mounted = false;
-        };
-    });
+    /**
+     * Name of the input element.
+     * - Data Attribute - `data-response-field-name`
+     * @defaultValue "cf-turnstile-response"
+     */
+    export let responseFieldName: RenderOptions['response-field-name'] =
+        'cf-turnstile-response';
 
-    function hasTurnstile() {
-        if (typeof window == 'undefined') return null;
-        return 'turnstile' in window;
-    }
-
-    function loadCallback() {
-        loaded = true;
-    }
-
-    function error() {
-        dispatch('turnstile-error', {});
-    }
-
-    function expired() {
-        dispatch('turnstile-expired', {});
-    }
-
-    function timeout() {
-        dispatch('turnstile-timeout', {});
-    }
-
-    function callback(token: string) {
-        dispatch('turnstile-callback', { token });
-    }
-
-    export function reset(): void {
+    /**
+     * Resets the widget.
+     * @param widgetId - The ID of the widget.
+     */
+    export const reset: TurnstileObject['reset'] = (): void => {
         window.turnstile.reset(widgetId);
-    }
+    };
 
-    const turnstile: Action = (node) => {
+    const events = {
+        /**
+         * Callback invoked when there is an error (e.g., network error, challenge failed).
+         * - Data Attribute - `data-error-callback`
+         * @see [Client-side errors](https://developers.cloudflare.com/turnstile/reference/client-side-errors)
+         */
+        'error-callback': {},
+        /**
+         * Callback invoked when the token expires and does not reset the widget.
+         * - Data Attribute - `data-expired-callback`
+         */
+        'expired-callback': {},
+        /**
+         * Callback invoked when the challenge expires.
+         * - Data Attribute - `data-timeout-callback`
+         */
+        'timeout-callback': {},
+        /**
+         * Callback invoked before the challenge enters interactive mode.
+         * - Data Attribute - `data-before-interactive-callback`
+         */
+        'before-interactive-callback': {},
+        /**
+         * Callback invoked when the challenge has left interactive mode.
+         * - Data Attribute - `data-after-interactive-callback`
+         */
+        'after-interactive-callback': {},
+        /**
+         * Callback invoked when a given client/browser is not supported.
+         * - Data Attribute - `data-unsupported-callback`
+         */
+        'unsupported-callback': {},
+    } as const;
+
+    const turnstileAction: Action = (node) => {
         const id = window.turnstile.render(node, {
-            'timeout-callback': timeout,
-            'expired-callback': expired,
-            'error-callback': error,
-            callback,
-
             sitekey: siteKey,
-
-            'response-field-name': formsField,
+            callback: (token: string) => dispatch('callback', { token }),
+            ...Object.fromEntries(
+                Object.keys(events).map((event) => [
+                    event,
+                    () => dispatch(event as keyof typeof events, {}),
+                ]),
+            ),
+            'response-field-name': responseFieldName,
+            'refresh-expired': refreshExpired,
             'retry-interval': retryInterval,
-            'response-field': forms,
+            'response-field': responseField,
             tabindex: tabIndex,
             appearance,
             execution,
@@ -89,7 +216,7 @@
             theme,
             cData,
             size,
-        });
+        })!;
 
         widgetId = id;
 
@@ -99,19 +226,37 @@
             },
         };
     };
+
+    function windowHasTurnstile() {
+        if (typeof window == 'undefined') return null;
+        return 'turnstile' in window;
+    }
+
+    function load() {
+        loaded = true;
+    }
+
+    onMount(() => {
+        mounted = true;
+
+        return () => {
+            mounted = false;
+        };
+    });
 </script>
 
 <svelte:head>
     {#if mounted && !loaded}
         <script
+            async
             src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
-            on:load={loadCallback}
-            async></script>
+            on:load={load}>
+        </script>
     {/if}
 </svelte:head>
 
 {#if loaded && mounted}
     {#key $$props}
-        <div use:turnstile />
+        <div use:turnstileAction />
     {/key}
 {/if}

--- a/src/lib/Turnstile.svelte
+++ b/src/lib/Turnstile.svelte
@@ -1,11 +1,3 @@
-<script lang="ts" context="module">
-    declare global {
-        interface Window {
-            turnstile: TurnstileObject;
-        }
-    }
-</script>
-
 <script lang="ts">
     import { createEventDispatcher, onMount } from 'svelte';
     import type { Action } from 'svelte/action';
@@ -18,7 +10,7 @@
 
     const dispatch = createEventDispatcher<Events>();
 
-    let loaded = windowHasTurnstile();
+    let loaded = typeof window != 'undefined' && 'turnstile' in window;
     let mounted = false;
 
     /**
@@ -33,8 +25,7 @@
      * @see https://developers.cloudflare.com/turnstile
      */
     export let turnstile: TurnstileObject | null = null;
-    $: turnstile =
-        windowHasTurnstile() && window.turnstile ? window.turnstile : null;
+    $: turnstile = (loaded && window.turnstile) || null;
 
     /**
      * Every widget has a sitekey. This sitekey is associated with the corresponding
@@ -213,11 +204,6 @@
             },
         };
     };
-
-    function windowHasTurnstile() {
-        if (typeof window == 'undefined') return null;
-        return 'turnstile' in window;
-    }
 
     onMount(() => {
         mounted = true;

--- a/src/lib/Turnstile.svelte
+++ b/src/lib/Turnstile.svelte
@@ -66,7 +66,7 @@
     /**
      * Execution controls when to obtain the token of the widget and can be on `"render"` (default) or on `"execute"`.
      * - Data Attribute - `data-execution`
-     * @defaultValue "render"
+     * @default "render"
      * @see [Execution modes](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#execution-modes)
      */
     export let execution: RenderParameters['execution'] = 'render';
@@ -91,14 +91,14 @@
      * Time between retry attempts in milliseconds. Value must be between `0` and `900000`
      * (15 minutes). Only applies when `retry` is set to `auto`.
      * - Data Attribute - `data-retry-interval`
-     * @defaultValue 8000
+     * @default 8000
      */
     export let retryInterval: RenderParameters['retry-interval'] = 8000;
 
     /**
      * Automatically retry upon failure to obtain a token or never retry.
      * - Data Attribute - `data-retry`
-     * @defaultValue "auto"
+     * @default "auto"
      */
     export let retry: RenderParameters['retry'] = 'auto';
 
@@ -106,7 +106,7 @@
      * Controls the behavior when the token of a Turnstile widget has expired.
      * Can be 'auto', 'manual', or 'never'.
      * - Data Attribute - `data-refresh-expired`
-     * @defaultValue "auto"
+     * @default "auto"
      */
     export let refreshExpired: RenderParameters['refresh-expired'] = 'auto';
 
@@ -119,14 +119,14 @@
     /**
      * The widget size. Can be 'normal' or 'compact'.
      * - Data Attribute - `data-size`
-     * @defaultValue "normal"
+     * @default "normal"
      */
     export let size: RenderParameters['size'] = 'normal';
 
     /**
      * The tabindex of Turnstile's iframe for accessibility purposes.
      * - Data Attribute - `data-tabindex`
-     * @defaultValue 0
+     * @default 0
      */
     export let tabIndex = 0;
 
@@ -138,7 +138,7 @@
     /**
      * Controls if an input element with the response token is created.
      * - Data Attribute - `data-response-field`
-     * @defaultValue true
+     * @default true
      */
     export let responseField: RenderParameters['response-field'] = true;
 
@@ -151,7 +151,7 @@
     /**
      * Name of the input element.
      * - Data Attribute - `data-response-field-name`
-     * @defaultValue "cf-turnstile-response"
+     * @default "cf-turnstile-response"
      */
     export let responseFieldName: RenderParameters['response-field-name'] =
         undefined;

--- a/src/lib/Turnstile.svelte
+++ b/src/lib/Turnstile.svelte
@@ -20,6 +20,10 @@
              * @param token - The token passed upon successful challenge.
              */
             callback: { token: string };
+            /**
+             * @deprecated Use `callback` instead.
+             */
+            'turnstile-callback': { token: string };
         } & typeof events
     >();
 
@@ -137,11 +141,22 @@
     export let tabIndex = 0;
 
     /**
+     * @deprecated Use `responseField` instead.
+     */
+    export let forms: RenderOptions['response-field'] = true;
+
+    /**
      * Controls if an input element with the response token is created.
      * - Data Attribute - `data-response-field`
      * @defaultValue true
      */
-    export let responseField: RenderOptions['response-field'] = true;
+    export let responseField: RenderOptions['response-field'] = true && forms;
+
+    /**
+     * @deprecated Use `responseFieldName` instead.
+     */
+    export let formsField: RenderOptions['response-field-name'] =
+        'cf-turnstile-response';
 
     /**
      * Name of the input element.
@@ -149,7 +164,7 @@
      * @defaultValue "cf-turnstile-response"
      */
     export let responseFieldName: RenderOptions['response-field-name'] =
-        'cf-turnstile-response';
+        formsField || 'cf-turnstile-response';
 
     /**
      * Resets the widget.
@@ -167,15 +182,31 @@
          */
         'error-callback': {},
         /**
+         * @deprecated Use `error-callback` instead.
+         */
+        'turnstile-error': {},
+
+        /**
          * Callback invoked when the token expires and does not reset the widget.
          * - Data Attribute - `data-expired-callback`
          */
         'expired-callback': {},
         /**
+         * @deprecated Use `expired-callback` instead.
+         */
+        'turnstile-expired': {},
+
+        /**
          * Callback invoked when the challenge expires.
          * - Data Attribute - `data-timeout-callback`
          */
         'timeout-callback': {},
+
+        /**
+         * @deprecated Use `timeout-callback` instead.
+         */
+        'turnstile-timeout': {},
+
         /**
          * Callback invoked before the challenge enters interactive mode.
          * - Data Attribute - `data-before-interactive-callback`
@@ -186,6 +217,7 @@
          * - Data Attribute - `data-after-interactive-callback`
          */
         'after-interactive-callback': {},
+
         /**
          * Callback invoked when a given client/browser is not supported.
          * - Data Attribute - `data-unsupported-callback`
@@ -196,7 +228,10 @@
     const turnstileAction: Action = (node) => {
         const id = window.turnstile.render(node, {
             sitekey: siteKey,
-            callback: (token: string) => dispatch('callback', { token }),
+            callback: (token: string) => {
+                dispatch('callback', { token });
+                dispatch('turnstile-callback', { token });
+            },
             ...Object.fromEntries(
                 Object.keys(events).map((event) => [
                     event,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -3,7 +3,7 @@ export type * from './types.d';
 // Export Turnstile component
 export { default as Turnstile } from './Turnstile.svelte';
 
-import type { TurnstileOptions } from './types.d';
+import type { TurnstileOptions } from 'turnstile-types';
 
 // Backwards compatibility (semver) for when we switched to turnstile-types
 export type TurnstileTheme = TurnstileOptions['theme'];

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,11 @@
-// Backwards compatibility (semver) for when we switched to turnstile-types
-export type { TurnstileTheme, TurnstileSize } from './types.d.ts';
+export type * from './types.d';
 
 // Export Turnstile component
 export { default as Turnstile } from './Turnstile.svelte';
+
+import type { TurnstileOptions } from './types.d';
+
+// Backwards compatibility (semver) for when we switched to turnstile-types
+export type TurnstileTheme = TurnstileOptions['theme'];
+export type TurnstileLanguage = TurnstileOptions['language'];
+export type TurnstileSize = TurnstileOptions['size'];

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -1,10 +1,260 @@
-import type { TurnstileOptions } from 'turnstile-types';
+/**
+ * Represents a rendered Turnstile widget.  Used to identify a specific widget when calling
+ * Turnstile methods.
+ */
+export type WidgetId = string;
 
-// Remove undefined from option
-export type Option<Key extends keyof TurnstileOptions> = Exclude<
-    TurnstileOptions[Key],
-    undefined
->;
+/**
+ * Turnstile is Cloudflare’s smart CAPTCHA alternative. It can be embedded into any website
+ * without sending traffic through Cloudflare and works without showing visitors a CAPTCHA.
+ * @see https://developers.cloudflare.com/turnstile
+ */
+export interface TurnstileObject {
+    /**
+     * If using synchronous loading, will be called once the DOM is ready.
+     * @see [Explicit Rendering](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#explicitly-render-the-turnstile-widget)
+     */
+    ready: (cb: () => any) => void;
 
-export type TurnstileTheme = Option<'theme'>;
-export type TurnstileSize = Option<'size'>;
+    /**
+     * @see [Implicit Rendering](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#implicitly-render-the-turnstile-widget)
+     */
+    implicitRender: () => void;
+
+    /**
+     * Excecutes the challenge after the render() function has been called, by invoking the
+     * turnstile.execute(container: string | HTMLElement, jsParams?: RenderParameters) function
+     * separately, decoupling the appearance and rendering of a widget from its execution.
+     * @see [Execution Modes](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#execution-modes)
+     */
+    execute: () => void;
+
+    /**
+     * Explicitly renders the Turnstile widget.  The `sitekey` parameter is required. The
+     * `callback` parameter, however, is only required if `execution` is set to `execute`.
+     * @param container - HTML container to render the widget.
+     * @param options - Configuration options for rendering. See {@link RenderOptions}.
+     * @returns A `widgetId` string if successful, otherwise undefined.
+     */
+    render(
+        container: HTMLElement | string,
+        options: RenderOptions,
+    ): string | undefined;
+
+    /**
+     * Resets the widget.
+     * @param widgetId - The ID of the widget.
+     */
+    reset(widgetId: WidgetId): void;
+
+    /**
+     * Removes the widget from the page.
+     * @param widgetId - The ID of the widget.
+     */
+    remove(widgetId: WidgetId): void;
+
+    /**
+     * Obtains the widget's response using its widgetId.
+     * @param widgetId - The ID of the widget.
+     */
+    getResponse(widgetId: WidgetId): string;
+
+    /**
+     * Checks if the widget has expired.
+     * @param widgetId - The ID of the widget.
+     */
+    isExpired(widgetId: WidgetId): boolean;
+}
+
+export type TurnstileOptions = RenderOptions;
+
+/**
+ * Interface for Turnstile rendering parameters.
+ */
+export interface RenderOptions {
+    /**
+     * Every widget has a sitekey. This sitekey is associated with the corresponding
+     * widget configuration and is created upon the widget creation.
+     * - Data Attribute - `data-sitekey`
+     */
+    sitekey: string;
+
+    /**
+     * A customer value that can be used to differentiate widgets under the same
+     * sitekey in analytics and which is returned upon validation. This can only
+     * contain up to 32 alphanumeric characters including `_` and `-`.
+     * - Data Attribute - `data-action`
+     */
+    action?: string;
+
+    /**
+     * A customer payload that can be used to attach customer data to the challenge
+     * throughout its issuance and which is returned upon validation. This can only
+     * contain up to 255 alphanumeric characters including `_` and `-`.
+     * - Data Attribute - `data-cdata`
+     */
+    cData?: string;
+
+    /**
+     * Callback function invoked upon successful challenge completion.
+     * - Data Attribute - `data-callback`
+     * @param token - The token passed upon successful challenge.
+     */
+    callback: (token: string) => void;
+
+    /**
+     * Callback invoked when there is an error (e.g., network error, challenge failed).
+     * - Data Attribute - `data-error-callback`
+     * @see [Client-side errors](https://developers.cloudflare.com/turnstile/reference/client-side-errors)
+     */
+    'error-callback'?: () => void;
+
+    /**
+     * Execution controls when to obtain the token of the widget and can be on `"render"` (default) or on `"execute"`.
+     * - Data Attribute - `data-execution`
+     * @defaultValue "render"
+     * @see [Execution modes](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#execution-modes)
+     */
+    execution?: 'render' | 'execute';
+
+    /**
+     * Callback invoked when the token expires and does not reset the widget.
+     * - Data Attribute - `data-expired-callback`
+     */
+    'expired-callback'?: () => void;
+
+    /**
+     * Callback invoked before the challenge enters interactive mode.
+     * - Data Attribute - `data-before-interactive-callback`
+     */
+    'before-interactive-callback'?: () => void;
+
+    /**
+     * Callback invoked when the challenge has left interactive mode.
+     * - Data Attribute - `data-after-interactive-callback`
+     */
+    'after-interactive-callback'?: () => void;
+
+    /**
+     * Callback invoked when a given client/browser is not supported.
+     * - Data Attribute - `data-unsupported-callback`
+     */
+    'unsupported-callback'?: () => void;
+
+    /**
+     * The widget theme. Can be `"light"`, `"dark"`, or `"auto"`.
+     * - Data Attribute - `data-theme`
+     */
+    theme?: 'light' | 'dark' | 'auto';
+
+    /**
+     * Language to display, either `"auto"` or an ISO 639-1 two-letter language code.
+     * - Data Attribute - `data-language`
+     * @see [language support FAQ](https://developers.cloudflare.com/turnstile/frequently-asked-questions/#what-languages-does-turnstile-support)
+     */
+    language?: SupportedLanguages | 'auto' | ISO;
+
+    /**
+     * The tabindex of Turnstile's iframe for accessibility purposes.
+     * - Data Attribute - `data-tabindex`
+     * @defaultValue 0
+     */
+    tabindex?: number;
+
+    /**
+     * Callback invoked when the challenge expires.
+     * - Data Attribute - `data-timeout-callback`
+     */
+    'timeout-callback'?: () => void;
+
+    /**
+     * Controls if an input element with the response token is created.
+     * - Data Attribute - `data-response-field`
+     * @defaultValue true
+     */
+    'response-field'?: boolean;
+
+    /**
+     * Name of the input element.
+     * - Data Attribute - `data-response-field-name`
+     * @defaultValue "cf-turnstile-response"
+     */
+    'response-field-name'?: string;
+
+    /**
+     * The widget size. Can be 'normal' or 'compact'.
+     * - Data Attribute - `data-size`
+     * @defaultValue "normal"
+     */
+    size?: 'normal' | 'compact';
+
+    /**
+     * Automatically retry upon failure to obtain a token or never retry.
+     * - Data Attribute - `data-retry`
+     * @defaultValue "auto"
+     */
+    retry?: 'auto' | 'never';
+
+    /**
+     * Time between retry attempts in milliseconds. Value must be between `0` and `900000`
+     * (15 minutes). Only applies when `retry` is set to `auto`.
+     * - Data Attribute - `data-retry-interval`
+     * @defaultValue 8000
+     */
+    'retry-interval'?: number;
+
+    /**
+     * Controls the behavior when the token of a Turnstile widget has expired.
+     * Can be 'auto', 'manual', or 'never'.
+     * - Data Attribute - `data-refresh-expired`
+     * @defaultValue "auto"
+     */
+    'refresh-expired'?: 'auto' | 'manual' | 'never';
+
+    /**
+     * Controls when the widget is visible:
+     * - `"always"` - The widget is visible at all times.
+     * - `"execute"` - The widget is visible only after the challenge begins.
+     * - `"interaction-only"` - The widget is visible only when an interaction is required.
+     *
+     * If a widget is visible, its appearance can be controlled via the `appearance` parameter.
+     * - Data Attribute - `data-appearance`
+     * @see
+     * [appearance-modes](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#appearance-modes)
+     */
+    appearance?: 'always' | 'execute' | 'interaction-only';
+
+    chlPageData?: string; // ENTERPRISE ONLY - undocumented
+}
+
+export type ISO = string & {};
+
+/**
+ * A list of supported languages for Turnstile.
+ * @see
+ * [language support FAQ](https://developers.cloudflare.com/turnstile/frequently-asked-questions/#what-languages-does-turnstile-support)
+ */
+export type SupportedLanguages =
+    | 'ar-eg'
+    | 'ar'
+    | 'de'
+    | 'en'
+    | 'es'
+    | 'fa'
+    | 'fr'
+    | 'id'
+    | 'it'
+    | 'ja'
+    | 'ko'
+    | 'nl'
+    | 'pl'
+    | 'pt'
+    | 'pt-br'
+    | 'ru'
+    | 'tlh'
+    | 'tr'
+    | 'uk'
+    | 'uk-ua'
+    | 'zh'
+    | 'zh-cn'
+    | 'zh-tw';

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -8,22 +8,22 @@ export interface Events {
     /**
      * @deprecated Use `error-callback` instead.
      */
-    'turnstile-error': {};
-    'error-callback': {};
+    'turnstile-error': { code: string };
+    error: { code: string };
 
     /**
-     * @deprecated Use `expired-callback` instead.
+     * @deprecated Use `expired` instead.
      */
     'turnstile-expired': {};
-    'expired-callback': {};
+    expired: {};
 
     /**
-     * @deprecated Use `timeout-callback` instead.
+     * @deprecated Use `timeout` instead.
      */
     'turnstile-timeout': {};
-    'timeout-callback': {};
+    timeout: {};
 
-    'before-interactive-callback': {};
-    'after-interactive-callback': {};
-    'unsupported-callback': {};
+    'before-interactive': {};
+    'after-interactive': {};
+    unsupported: {};
 }

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -1,260 +1,29 @@
-/**
- * Represents a rendered Turnstile widget.  Used to identify a specific widget when calling
- * Turnstile methods.
- */
-export type WidgetId = string;
-
-/**
- * Turnstile is Cloudflare’s smart CAPTCHA alternative. It can be embedded into any website
- * without sending traffic through Cloudflare and works without showing visitors a CAPTCHA.
- * @see https://developers.cloudflare.com/turnstile
- */
-export interface TurnstileObject {
+export interface Events {
     /**
-     * If using synchronous loading, will be called once the DOM is ready.
-     * @see [Explicit Rendering](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#explicitly-render-the-turnstile-widget)
+     * @deprecated Use `callback` instead.
      */
-    ready: (cb: () => any) => void;
+    'turnstile-callback': { token: string };
+    callback: { token: string };
 
     /**
-     * @see [Implicit Rendering](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#implicitly-render-the-turnstile-widget)
+     * @deprecated Use `error-callback` instead.
      */
-    implicitRender: () => void;
+    'turnstile-error': {};
+    'error-callback': {};
 
     /**
-     * Excecutes the challenge after the render() function has been called, by invoking the
-     * turnstile.execute(container: string | HTMLElement, jsParams?: RenderParameters) function
-     * separately, decoupling the appearance and rendering of a widget from its execution.
-     * @see [Execution Modes](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#execution-modes)
+     * @deprecated Use `expired-callback` instead.
      */
-    execute: () => void;
+    'turnstile-expired': {};
+    'expired-callback': {};
 
     /**
-     * Explicitly renders the Turnstile widget.  The `sitekey` parameter is required. The
-     * `callback` parameter, however, is only required if `execution` is set to `execute`.
-     * @param container - HTML container to render the widget.
-     * @param options - Configuration options for rendering. See {@link RenderOptions}.
-     * @returns A `widgetId` string if successful, otherwise undefined.
+     * @deprecated Use `timeout-callback` instead.
      */
-    render(
-        container: HTMLElement | string,
-        options: RenderOptions,
-    ): string | undefined;
+    'turnstile-timeout': {};
+    'timeout-callback': {};
 
-    /**
-     * Resets the widget.
-     * @param widgetId - The ID of the widget.
-     */
-    reset(widgetId: WidgetId): void;
-
-    /**
-     * Removes the widget from the page.
-     * @param widgetId - The ID of the widget.
-     */
-    remove(widgetId: WidgetId): void;
-
-    /**
-     * Obtains the widget's response using its widgetId.
-     * @param widgetId - The ID of the widget.
-     */
-    getResponse(widgetId: WidgetId): string;
-
-    /**
-     * Checks if the widget has expired.
-     * @param widgetId - The ID of the widget.
-     */
-    isExpired(widgetId: WidgetId): boolean;
+    'before-interactive-callback': {};
+    'after-interactive-callback': {};
+    'unsupported-callback': {};
 }
-
-export type TurnstileOptions = RenderOptions;
-
-/**
- * Interface for Turnstile rendering parameters.
- */
-export interface RenderOptions {
-    /**
-     * Every widget has a sitekey. This sitekey is associated with the corresponding
-     * widget configuration and is created upon the widget creation.
-     * - Data Attribute - `data-sitekey`
-     */
-    sitekey: string;
-
-    /**
-     * A customer value that can be used to differentiate widgets under the same
-     * sitekey in analytics and which is returned upon validation. This can only
-     * contain up to 32 alphanumeric characters including `_` and `-`.
-     * - Data Attribute - `data-action`
-     */
-    action?: string;
-
-    /**
-     * A customer payload that can be used to attach customer data to the challenge
-     * throughout its issuance and which is returned upon validation. This can only
-     * contain up to 255 alphanumeric characters including `_` and `-`.
-     * - Data Attribute - `data-cdata`
-     */
-    cData?: string;
-
-    /**
-     * Callback function invoked upon successful challenge completion.
-     * - Data Attribute - `data-callback`
-     * @param token - The token passed upon successful challenge.
-     */
-    callback: (token: string) => void;
-
-    /**
-     * Callback invoked when there is an error (e.g., network error, challenge failed).
-     * - Data Attribute - `data-error-callback`
-     * @see [Client-side errors](https://developers.cloudflare.com/turnstile/reference/client-side-errors)
-     */
-    'error-callback'?: () => void;
-
-    /**
-     * Execution controls when to obtain the token of the widget and can be on `"render"` (default) or on `"execute"`.
-     * - Data Attribute - `data-execution`
-     * @defaultValue "render"
-     * @see [Execution modes](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#execution-modes)
-     */
-    execution?: 'render' | 'execute';
-
-    /**
-     * Callback invoked when the token expires and does not reset the widget.
-     * - Data Attribute - `data-expired-callback`
-     */
-    'expired-callback'?: () => void;
-
-    /**
-     * Callback invoked before the challenge enters interactive mode.
-     * - Data Attribute - `data-before-interactive-callback`
-     */
-    'before-interactive-callback'?: () => void;
-
-    /**
-     * Callback invoked when the challenge has left interactive mode.
-     * - Data Attribute - `data-after-interactive-callback`
-     */
-    'after-interactive-callback'?: () => void;
-
-    /**
-     * Callback invoked when a given client/browser is not supported.
-     * - Data Attribute - `data-unsupported-callback`
-     */
-    'unsupported-callback'?: () => void;
-
-    /**
-     * The widget theme. Can be `"light"`, `"dark"`, or `"auto"`.
-     * - Data Attribute - `data-theme`
-     */
-    theme?: 'light' | 'dark' | 'auto';
-
-    /**
-     * Language to display, either `"auto"` or an ISO 639-1 two-letter language code.
-     * - Data Attribute - `data-language`
-     * @see [language support FAQ](https://developers.cloudflare.com/turnstile/frequently-asked-questions/#what-languages-does-turnstile-support)
-     */
-    language?: SupportedLanguages | 'auto' | ISO;
-
-    /**
-     * The tabindex of Turnstile's iframe for accessibility purposes.
-     * - Data Attribute - `data-tabindex`
-     * @defaultValue 0
-     */
-    tabindex?: number;
-
-    /**
-     * Callback invoked when the challenge expires.
-     * - Data Attribute - `data-timeout-callback`
-     */
-    'timeout-callback'?: () => void;
-
-    /**
-     * Controls if an input element with the response token is created.
-     * - Data Attribute - `data-response-field`
-     * @defaultValue true
-     */
-    'response-field'?: boolean;
-
-    /**
-     * Name of the input element.
-     * - Data Attribute - `data-response-field-name`
-     * @defaultValue "cf-turnstile-response"
-     */
-    'response-field-name'?: string;
-
-    /**
-     * The widget size. Can be 'normal' or 'compact'.
-     * - Data Attribute - `data-size`
-     * @defaultValue "normal"
-     */
-    size?: 'normal' | 'compact';
-
-    /**
-     * Automatically retry upon failure to obtain a token or never retry.
-     * - Data Attribute - `data-retry`
-     * @defaultValue "auto"
-     */
-    retry?: 'auto' | 'never';
-
-    /**
-     * Time between retry attempts in milliseconds. Value must be between `0` and `900000`
-     * (15 minutes). Only applies when `retry` is set to `auto`.
-     * - Data Attribute - `data-retry-interval`
-     * @defaultValue 8000
-     */
-    'retry-interval'?: number;
-
-    /**
-     * Controls the behavior when the token of a Turnstile widget has expired.
-     * Can be 'auto', 'manual', or 'never'.
-     * - Data Attribute - `data-refresh-expired`
-     * @defaultValue "auto"
-     */
-    'refresh-expired'?: 'auto' | 'manual' | 'never';
-
-    /**
-     * Controls when the widget is visible:
-     * - `"always"` - The widget is visible at all times.
-     * - `"execute"` - The widget is visible only after the challenge begins.
-     * - `"interaction-only"` - The widget is visible only when an interaction is required.
-     *
-     * If a widget is visible, its appearance can be controlled via the `appearance` parameter.
-     * - Data Attribute - `data-appearance`
-     * @see
-     * [appearance-modes](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#appearance-modes)
-     */
-    appearance?: 'always' | 'execute' | 'interaction-only';
-
-    chlPageData?: string; // ENTERPRISE ONLY - undocumented
-}
-
-export type ISO = string & {};
-
-/**
- * A list of supported languages for Turnstile.
- * @see
- * [language support FAQ](https://developers.cloudflare.com/turnstile/frequently-asked-questions/#what-languages-does-turnstile-support)
- */
-export type SupportedLanguages =
-    | 'ar-eg'
-    | 'ar'
-    | 'de'
-    | 'en'
-    | 'es'
-    | 'fa'
-    | 'fr'
-    | 'id'
-    | 'it'
-    | 'ja'
-    | 'ko'
-    | 'nl'
-    | 'pl'
-    | 'pt'
-    | 'pt-br'
-    | 'ru'
-    | 'tlh'
-    | 'tr'
-    | 'uk'
-    | 'uk-ua'
-    | 'zh'
-    | 'zh-cn'
-    | 'zh-tw';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-    import { Turnstile, type TurnstileSize, type TurnstileTheme } from '$lib';
+    import type { TurnstileTheme, TurnstileSize } from '$lib';
     import type { ActionData } from './$types';
+
     import { enhance } from '$app/forms';
+    import { Turnstile } from '$lib';
 
     export let form: ActionData;
 
@@ -66,7 +68,15 @@
 
 <section>
     <form method="POST" use:enhance>
-        <Turnstile {size} {siteKey} {theme} bind:reset />
+        <Turnstile
+            {size}
+            {theme}
+            {siteKey}
+            bind:reset
+            appearance="interaction-only"
+            on:turnstile-before-interactive={() => {
+                alert('before-interactive');
+            }} />
         <input type="hidden" name="secret" bind:value={secretKey} />
 
         <div class="row">
@@ -78,8 +88,6 @@
     <p style="margin-top: 8px;">
         {#if form}
             {form.error ? `Error: ${form.error}` : 'Success'}
-        {:else}
-            Not submitted form
         {/if}
     </p>
 </section>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -68,15 +68,7 @@
 
 <section>
     <form method="POST" use:enhance>
-        <Turnstile
-            {size}
-            {theme}
-            {siteKey}
-            bind:reset
-            appearance="interaction-only"
-            on:turnstile-before-interactive={() => {
-                alert('before-interactive');
-            }} />
+        <Turnstile {size} {theme} {siteKey} bind:reset />
         <input type="hidden" name="secret" bind:value={secretKey} />
 
         <div class="row">

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,15 +1,15 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 import adapter from '@sveltejs/adapter-auto';
-import preprocess from 'svelte-preprocess';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	// Consult https://github.com/sveltejs/svelte-preprocess
-	// for more information about preprocessors
-	preprocess: preprocess(),
+    // Consult https://github.com/sveltejs/svelte-preprocess
+    // for more information about preprocessors
+    preprocess: vitePreprocess(),
 
-	kit: {
-		adapter: adapter()
-	}
+    kit: {
+        adapter: adapter(),
+    },
 };
 
 export default config;


### PR DESCRIPTION
The types are internal now, but we can switch back to `turnstile-types` if this is merged https://github.com/Le0Developer/turnstile-types/pull/2

I opted to respecting the original naming to mitigate additional api discovery overhead, but I added backwards compatibility with and marked the relevant fields with `@deprecated`.

I removed the ❌ emojis from the README as they were distracting.

I edited the `package.json` out of habit but feel free to ignore that one.