### PR TITLE
refactor: load turnstile script manually

### DIFF
--- a/src/lib/Turnstile.svelte
+++ b/src/lib/Turnstile.svelte
@@ -34,6 +34,16 @@
     onMount(() => {
         mounted = true;
 
+        if (!loaded) {
+            let script = document.createElement('script');
+            script.type = 'text/javascript';
+            script.src =
+                'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
+            script.async = true;
+            script.addEventListener('load', loadCallback);
+            document.head.appendChild(script);
+        }
+
         return () => {
             mounted = false;
         };
@@ -100,15 +110,6 @@
         };
     };
 </script>
-
-<svelte:head>
-    {#if mounted && !loaded}
-        <script
-            src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
-            on:load={loadCallback}
-            async></script>
-    {/if}
-</svelte:head>
 
 {#if loaded && mounted}
     {#key $$props}


### PR DESCRIPTION
Fixes: #22 

Modifying script loading to accommodate the upcoming release of Svelte 5. The `on:load` event for scripts placed inside `<svelte:head>` does not fire in Svelte 5 as a result of this bug:
https://github.com/sveltejs/svelte/issues/8301

Instead of loading the Cloudfare Turnstile script in `<svelte:head>`, load the script dynamically during mount. This is functionally equivalent to using `<svelte:head>` but accommodates an operational load event handler. If Svelte 5 resolves Issue 8301, this is not needed.
- - -
This pull request can be reviewed on [<img src="https://gitcontext.com/logo/GitContextButton.svg" height="32" align="absmiddle" alt="GitContext.com"/>](https://gitcontext.com/app/prs/github/ghostdevv/svelte-turnstile/pull/23)