### PR TITLE
docs: add Superforms example for Svelte 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,6 @@ export const schema = z.object({
 import { fail, message, setError, superValidate } from 'sveltekit-superforms';
 import { zod } from 'sveltekit-superforms/adapters';
 import { schema } from './schema.ts';
-import { z } from 'zod';
 
 export const load = async () => {
 	const form = await superValidate(zod(schema));

--- a/README.md
+++ b/README.md
@@ -192,9 +192,6 @@ export const schema = z.object({
 		on:callback={(event) => {
 			$formData['cf-turnstile-response'] = event.detail.token;
 		}}
-		on:expired={() => {
-			reset?.();
-		}}
 		siteKey={PUBLIC_TURNSTILE_SITE_KEY}
 		bind:reset />
 </form>

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ async function validateToken(token: string, secret: string) {
 }
 ```
 
-## SvelteKit Example
+## SvelteKit Example (Svelte 5)
 
 In SvelteKit we can use form actions to easily setup a form with a captcha:
 
@@ -200,7 +200,7 @@ export const schema = z.object({
 </form>
 ```
 
-This example uses the [superforms events](https://superforms.rocks/concepts/events) to reset the turnstile widget when the form is updated and automatically add the token to the form data.
+This example uses the [Superforms onUpdated event](https://superforms.rocks/concepts/events) to reset the Turnstile widget. Additionally, it automatically adds the Turnstile response token to the form data.
 
 # Resetting
 


### PR DESCRIPTION
This PR adds superforms example to the README.md using superforms onUpdated event to reset the widget and svelte-turnstile callback to set token

![events C0HjOx0t](https://github.com/user-attachments/assets/adacabbd-36d7-405d-8374-5b118f504132)
