### PR TITLE
feat: add preClearanceObtained to the callback event

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,15 @@ For more information about some of the props and a list of `SupportedLanguage`'s
 
 ## Events
 
-| Event                | Data                | Description                                                    |
-| -------------------- | ------------------- | -------------------------------------------------------------- |
-| `callback`           | `{ token: string }` | Emitted when a user passes a challenge                         |
-| `error`              | `{ code: string }`  | Emitted when a user fails verification                         |
-| `expired`            | `{}`                | Emitted when a challenge expires and does not reset the widget |
-| `timeout`            | `{}`                | Emitted when a challenge expires and does reset the widget     |
-| `before-interactive` | `{}`                | Emitted before the challenge enters interactive mode           |
-| `after-interactive`  | `{}`                | Emitted when the challenge has left interactive mode           |
-| `unsupported`        | `{}`                | Emitted when a given client/browser is not supported           |
+| Event                | Data                                                | Description                                                    |
+| -------------------- | --------------------------------------------------- | -------------------------------------------------------------- |
+| `callback`           | `{ token: string; preClearanceObtained: boolean; }` | Emitted when a user passes a challenge                         |
+| `error`              | `{ code: string }`                                  | Emitted when a user fails verification                         |
+| `expired`            | `{}`                                                | Emitted when a challenge expires and does not reset the widget |
+| `timeout`            | `{}`                                                | Emitted when a challenge expires and does reset the widget     |
+| `before-interactive` | `{}`                                                | Emitted before the challenge enters interactive mode           |
+| `after-interactive`  | `{}`                                                | Emitted when the challenge has left interactive mode           |
+| `unsupported`        | `{}`                                                | Emitted when a given client/browser is not supported           |
 
 # Validate CAPTCHA
 

--- a/src/lib/Turnstile.svelte
+++ b/src/lib/Turnstile.svelte
@@ -149,9 +149,9 @@
 
 	$: renderParams = {
 		sitekey: siteKey,
-		callback: (token: string) => {
-			dispatch('callback', { token });
-			dispatch('turnstile-callback', { token });
+		callback: (token: string, preClearanceObtained: boolean) => {
+			dispatch('callback', { token, preClearanceObtained });
+			dispatch('turnstile-callback', { token, preClearanceObtained });
 		},
 		'error-callback': (code) => {
 			dispatch('error', { code });

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -3,13 +3,15 @@ export interface Events {
 	 * Deprecated - use `callback` instead.
 	 * @deprecated
 	 */
-	'turnstile-callback': { token: string };
+	'turnstile-callback': { token: string; preClearanceObtained: boolean };
 
 	/**
 	 * Callback function invoked upon successful challenge completion.
-	 * @param { token: string } - The token passed upon successful challenge.
+	 * @param detail - An object containing details about the event.
+	 * @param detail.token - The token received upon successful challenge completion.
+	 * @param detail.preClearanceObtained - Boolean indicating if the clearance was obtained.
 	 */
-	callback: { token: string };
+	callback: { token: string; preClearanceObtained: boolean };
 
 	/**
 	 * Deprecated - use `error-callback` instead.


### PR DESCRIPTION
## Info
Added `preClearanceObtained` property to `callback` event detail. This will allow integrating Turnstile with the Cloudflare WAF to challenge fetch requests. 

See example [here](https://blog.cloudflare.com/integrating-turnstile-with-the-cloudflare-waf-to-challenge-fetch-requests)

## References
https://developers.cloudflare.com/turnstile/concepts/pre-clearance-support/

